### PR TITLE
Listen for new systemd units and monitor them if needed.

### DIFF
--- a/healthagent/healthagent.py
+++ b/healthagent/healthagent.py
@@ -173,7 +173,7 @@ class Healthagent:
             #TODO: Future work
             # Right now list of services are hardcoded, and any service not loaded on a node is automatically ignored.
             # But this list eventually needs to come either through the CLI or through the config file.
-            await systemd.add_monitor(services=["munge.service", "slurmd.service", "slurmctld.service", "slurmdbd.service"])
+            await systemd.add_monitor(services=["munge.service", "slurmd.service", "slurmctld.service", "slurmdbd.service", "slurmrestd.service", "nvidia-imex.service", "nvidia-dcgm.service"])
         except Exception as e:
             log.exception(e)
 

--- a/specs/default/cluster-init/scripts/00-install.sh
+++ b/specs/default/cluster-init/scripts/00-install.sh
@@ -13,6 +13,8 @@ DCGM_VERSION="4.2.3"
 
 
 setup_venv() {
+    set -x
+
     if [ -f /etc/os-release ]; then
         . /etc/os-release
         OS=$ID
@@ -61,6 +63,9 @@ setup_venv() {
 }
 
 download_install_healthagent() {
+
+    set -x
+
     cd $HEALTHAGENT_DIR
     # Check if the package already exists and delete it if it does
     if [ -f "$PACKAGE" ]; then
@@ -78,6 +83,8 @@ download_install_healthagent() {
     deactivate
 }
 setup_dcgm() {
+    set -x
+
     echo "Setting up DCGM (Datacenter GPU Manager)..."
 
     # Detect the operating system
@@ -135,6 +142,8 @@ setup_dcgm() {
 }
 
 setup_systemd() {
+    set -x
+
     # Create the systemd service file
     echo "Creating systemd service file at $SERVICE_FILE..."
     cat <<EOL > $SERVICE_FILE


### PR DESCRIPTION
If our list of units to monitor get enabled/started later,
start monitoring it from that point onwards.

Add set -x to individual functions in installation script.