### PR TITLE
Connect to DCGM in embedded mode.

### DIFF
--- a/healthagent/bindings.py
+++ b/healthagent/bindings.py
@@ -209,7 +209,8 @@ class Wrap:
         opMode = dcgm_structs.DCGM_OPERATION_MODE_AUTO
         # create a dcgm handle by connecting to host engine process
         try:
-            dcgmHandle = pydcgm.DcgmHandle(ipAddress='127.0.0.1', opMode=opMode)
+            # Load DCGM library in embedded mode by not giving an IP address.
+            dcgmHandle = pydcgm.DcgmHandle(opMode=opMode)
 
             ## Get a handle to the system level object for DCGM
             dcgmSystem = dcgmHandle.GetSystem()
@@ -231,6 +232,13 @@ class Wrap:
         dcgmSystem.UpdateAllFields(waitForUpdate=True)
         return dcgmGroup,dcgmHandle
 
+    @classmethod
+    def disconnect(cls, handle, grp):
+        if grp:
+            grp.Delete()
+            del(grp)
+        if handle:
+            del(handle)
 
     @classmethod
     def set_policy(cls, mpe):

--- a/healthagent/gpu.py
+++ b/healthagent/gpu.py
@@ -278,20 +278,7 @@ class GpuHealthChecks:
 
             except dcgm_structs.DCGMError as e:
                 code = e.value
-                if code == dcgm_structs.DCGM_ST_CONNECTION_NOT_VALID:
-                    # We lost connection to DCGM, try to re-initialize.
-                    log.error("Connection not valid, Re-initializing connection to nvidia-dcgm")
-                    try:
-                        self.setup()
-                    except Wrap.DcgmConnectionFail as e:
-                        log.critical("Unable to connect to DCGM, is the DCGM service running?")
-                        log.critical("To re-instantiate checks, start the dcgm service.")
-                        # cancel this job from repeating, since it will fail anyway.
-                        Scheduler.cancel_task()
-                    else:
-                        log.info("Re-initialized our connection to DCGM.")
-                else:
-                    log.error("dcgmHealthCheck returned error %d: %s" % (code, e))
+                log.error("dcgmHealthCheck returned error %d: %s" % (code, e))
         except Exception as e:
             log.exception(f"{e}")
 

--- a/healthagent/gpu.py
+++ b/healthagent/gpu.py
@@ -373,5 +373,7 @@ def run_active_healthchecksv2():
         report.description = f"DCGM Epilog failures in {', '.join(test_types)}"
         report.message = "GPU Epilog Errors"
         report.custom_fields = custom_fields
+
+    Wrap.disconnect(dcgmHandle, dcgmGroup)
     return report
 


### PR DESCRIPTION
By not giving an IP address, we connect to DCGM in embedded mode and not via the host engine wrapper which brings in a systemd dependency.

Additionally remove long lived process pools. This makes epilog checks more resilient.