### PR TITLE
Handle persistent mode differently.

### DIFF
--- a/healthagent/bindings.py
+++ b/healthagent/bindings.py
@@ -52,6 +52,7 @@ class Wrap:
         FABRIC_STATUS = dcgm_fields.DCGM_FI_DEV_FABRIC_MANAGER_STATUS
         FABRIC_ERROR = dcgm_fields.DCGM_FI_DEV_FABRIC_MANAGER_ERROR_CODE
         GPUPOWER = dcgm_fields.DCGM_FI_DEV_POWER_USAGE
+        PERSISTENCE_MODE = dcgm_fields.DCGM_FI_DEV_PERSISTENCE_MODE
 
     @classmethod
     def get_throttle_reasons(cls, clock_reason):
@@ -97,7 +98,8 @@ class Wrap:
             Wrap.fields.GPUPOWER,
             Wrap.fields.GPUTEMP,
             Wrap.fields.GPUTEMP_SHUTDOWN,
-            Wrap.fields.GPUTEMP_SLOWDOWN
+            Wrap.fields.GPUTEMP_SLOWDOWN,
+            Wrap.fields.PERSISTENCE_MODE
         ]
 
     @classmethod

--- a/healthagent/healthagent.py
+++ b/healthagent/healthagent.py
@@ -289,7 +289,7 @@ class Healthagent:
             #TODO: Future work
             # Right now list of services are hardcoded, and any service not loaded on a node is automatically ignored.
             # But this list eventually needs to come either through the CLI or through the config file.
-            await systemd.add_monitor(services=["munge.service", "slurmd.service", "slurmctld.service", "slurmdbd.service", "slurmrestd.service", "nvidia-imex.service", "nvidia-dcgm.service"])
+            await systemd.add_monitor(services=["munge.service", "slurmd.service", "slurmctld.service", "slurmdbd.service", "slurmrestd.service", "nvidia-imex.service", "nvidia-dcgm.service","nvidia-persistenced.service"])
         except Exception as e:
             log.exception(e)
 


### PR DESCRIPTION
Earlier persistence mode was not set on GPU's, which healthagent attempted to do at the start. This fails as now nvidia-persistenced service is constantly running. Now we should track persistence mode and show an error if the service is not running. We track it both by DCGM fields as well as through systemd monitoring.

This does mean that healthagent will not be setting the persistence mode anymore (it was failing anyway since images now contain a systemd service thats set to start on boot). 

In the future-- when we build remediation strategies-- our goal would be to schedule certain tasks to run on epilog etc and restarting persistence mode service maybe one of them.

Additionally this PR does add systemd monitoring for persistenced as well, so if the service fails for a catastrophic reason then we will get notified.

This PR also adjusts the thermal limit to 95% of the slowdown temperature (based on discussion with Nvidia)