### PR TITLE
Add a test mode for DCGM

### DIFF
--- a/healthagent/bindings.py
+++ b/healthagent/bindings.py
@@ -203,7 +203,7 @@ class Wrap:
         return False
 
     @classmethod
-    def connect(cls, grp_name: str):
+    def connect(cls, grp_name: str, test_mode=False):
         ## Initialize the DCGM Engine as automatic operation mode. This is required when connecting
         ## to a "standalone" hostengine (one that is running separately) but can also be done on an
         ## embedded hostengine.  In this mode, fields are updated
@@ -211,8 +211,14 @@ class Wrap:
         opMode = dcgm_structs.DCGM_OPERATION_MODE_AUTO
         # create a dcgm handle by connecting to host engine process
         try:
-            # Load DCGM library in embedded mode by not giving an IP address.
-            dcgmHandle = pydcgm.DcgmHandle(opMode=opMode)
+            if test_mode:
+                # Connect to DCGM host engine, useful for using DCGM error injection framework for injecting errors and
+                # validating healthagent actions.
+                dcgmHandle = pydcgm.DcgmHandle(ipAddress="127.0.0.1", opMode=opMode)
+            else:
+                # Load DCGM library in embedded mode. In embedded mode, DCGM library is loaded as a shared library. This
+                # is the production mode.
+                dcgmHandle = pydcgm.DcgmHandle(opMode=opMode)
 
             ## Get a handle to the system level object for DCGM
             dcgmSystem = dcgmHandle.GetSystem()

--- a/healthagent/bindings.py
+++ b/healthagent/bindings.py
@@ -39,6 +39,9 @@ class Wrap:
     class DcgmConnectionFail(Exception):
         pass
 
+    class DcgmInvalidHandle(Exception):
+        pass
+
     class DcgmGpuNotFound(Exception):
         pass
 

--- a/healthagent/healthagent.py
+++ b/healthagent/healthagent.py
@@ -310,7 +310,7 @@ class Healthagent:
         except Exception as e:
             log.exception(e)
 
-        try: 
+        try:
             from healthagent.kmsg import KmsgReader
             module = 'kmsg'
             reporter = self.get_reporter(module=module)

--- a/healthagent/reporter.py
+++ b/healthagent/reporter.py
@@ -121,7 +121,7 @@ class Reporter:
                 log.debug(f"Clearing previous error report for {name}")
                 await self.update_report(name=name, report=HealthReport())
 
-    async def update_report(self, name: str, report: HealthReport, send: bool = True):
+    async def update_report(self, name: str, report: HealthReport):
 
         if not name:
             raise ValueError("The 'name' argument cannot be None")
@@ -145,8 +145,7 @@ class Reporter:
         last_report = self.store.get(name)
         if not last_report or (last_report != report):
             self.store[name] = report
-            if send:
-                await self._report_health_status(name)
+            await self._report_health_status(name)
         else:
             # still update the last_update
             self.store[name].last_update = report.last_update

--- a/healthagent/reporter.py
+++ b/healthagent/reporter.py
@@ -121,7 +121,7 @@ class Reporter:
                 log.debug(f"Clearing previous error report for {name}")
                 await self.update_report(name=name, report=HealthReport())
 
-    async def update_report(self, name: str, report: HealthReport):
+    async def update_report(self, name: str, report: HealthReport, send: bool = True):
 
         if not name:
             raise ValueError("The 'name' argument cannot be None")
@@ -145,7 +145,8 @@ class Reporter:
         last_report = self.store.get(name)
         if not last_report or (last_report != report):
             self.store[name] = report
-            await self._report_health_status(name)
+            if send:
+                await self._report_health_status(name)
         else:
             # still update the last_update
             self.store[name].last_update = report.last_update


### PR DESCRIPTION
This allows healthagent GPU tests to run via nvidia-dcgm service.
This is not the default mode. By default DCGM library is loaded in
embedded mode to avoid reliance on nvidia-dcgm service in production.

In test-mode healthagent loads the dcgm library by connecting to
nvidia-dcgm service and this facilitates testing of DCGM api.
This mode is only for testing.