### PR TITLE
Add publish_cc variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,16 @@ And then `health -s` should show the injected values:
 [DCGM Modes](https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/getting-started.html#modes-of-operation)
 
 [DCGM Test Injection Framework](https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/dcgm-error-injection.html#error-injection-workflow)
+
+### CycleCloud Integration
+
+Healthagent reports status of the nodes to CycleCloud via `jetpack`. This can be explicitly disabled by setting `PUBLISH_CC` to `False`. Default value is `True`. Additionally if healthagent is unable to find jetpack binary, then CC reporting is automatically disabled regardless of the value of the environment variable. The environment variable can be configured in healthagent systemd file.
+
+```bash
+[Service]
+Environment="PUBLISH_CC=False"
+```
+
 ### WIP
 
 - configurability of health checks

--- a/healthagent/healthagent.py
+++ b/healthagent/healthagent.py
@@ -185,7 +185,7 @@ class Healthagent:
         if os.path.exists(filename):
             try:
                 with open(filename, 'rb') as f:
-                    return pickle.load(f)
+                    return Reporter.load_reporter_obj(old=pickle.load(f))
             except Exception as e:
                 log.error(e)
                 log.error(f"Unable to restore previous state for module {module}")


### PR DESCRIPTION
This can be set to enable/disable if reports are to be sent via jetpack or not. By default its always enabled. If however the jetpack binary is not found, then it gets disabled.

Environment variable can be set through systemd config file. (later healthagent configuration file can also be used to expose these knobs)