### PR TITLE
Only add gpu related services if gpu healthchecks are enabled.

### DIFF
--- a/healthagent/healthagent.py
+++ b/healthagent/healthagent.py
@@ -306,7 +306,10 @@ class Healthagent:
             #TODO: Future work
             # Right now list of services are hardcoded, and any service not loaded on a node is automatically ignored.
             # But this list eventually needs to come either through the CLI or through the config file.
-            await systemd.add_monitor(services=["munge.service", "slurmd.service", "slurmctld.service", "slurmdbd.service", "slurmrestd.service", "nvidia-imex.service", "nvidia-dcgm.service","nvidia-persistenced.service"])
+            await systemd.add_monitor(services=["munge.service", "slurmd.service", "slurmctld.service", "slurmdbd.service", "slurmrestd.service"])
+            if 'gpu' in self.modules:
+                await systemd.add_monitor(services=["nvidia-imex.service", "nvidia-dcgm.service", "nvidia-persistenced.service"])
+
         except Exception as e:
             log.exception(e)
 


### PR DESCRIPTION
This prevents systemd monitoring for nvidia services on login nodes.