### PR TITLE
Fix a bug in systemd checks

### DIFF
--- a/healthagent/async_systemd.py
+++ b/healthagent/async_systemd.py
@@ -105,7 +105,7 @@ class SystemdMonitor:
                 log.error(report.description)
                 await self.reporter.update_report(name=service, report=report)
             elif active_state == "active" and substate == "running":
-                if self.state.get(service) == "failed":
+                if self.state.get(service) in ("failed", "inactive"):
                     log.info(f"{service} Service Healthy")
                     report.status = HealthStatus.OK
                     await self.reporter.update_report(name=service, report=report)


### PR DESCRIPTION
When a service recovers, we rely on detecting state transition from "failed" to "active". But often when services have "Restart=always" configured, they might be transitioning from inactive to active.

This allows us to detect recovery for all cases.