### PR TITLE
Downgrade specific errors to warnings.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,10 @@
 {   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
 
     "python.autoComplete.extraPaths": [
-        "${workspaceFolder}/.bindings/dcgm-4.2.2/"
+        
+        "${workspaceFolder}/.bindings/dcgm-4.5.0/"
     ],
     "python.analysis.extraPaths": [
-        "${workspaceFolder}/.bindings/dcgm-4.2.2/"
+        "${workspaceFolder}/.bindings/dcgm-4.5.0/"
     ],
 }

--- a/healthagent/bindings.py
+++ b/healthagent/bindings.py
@@ -36,6 +36,7 @@ try:
     from dcgm_structs import dcgmExceptionClass
     import dcgm_structs
     import dcgm_fields
+    import dcgm_errors
     import dcgm_agent
     import dcgmvalue
     import DcgmFieldGroup
@@ -238,6 +239,14 @@ class Wrap:
         if system == dcgm_structs.DCGM_HEALTH_WATCH_DRIVER:
             return "Driver"
 
+        if system == dcgm_structs.DCGM_HEALTH_WATCH_NVSWITCH_FATAL:
+            return "Nvswitch"
+
+        if system == dcgm_structs.DCGM_HEALTH_WATCH_NVSWITCH_NONFATAL:
+            return "Nvswitch"
+
+        return "System"
+
     ## Helper method to convert DCGM value to string
     @classmethod
     def convert_value_to_string(cls, value):
@@ -260,7 +269,7 @@ class Wrap:
                 return v.__str__()
 
     @classmethod
-    def convert_overall_health_to_string(cls, health):
+    def convert_health_to_status(cls, health):
         """
         helper method to convert helath return to a string for display purpose
         """


### PR DESCRIPTION
Some XID errors do not require intervention and GPU can continue working normall after them. Downgrade XID 43 and 63 to warning.

NVLINK BER thresholds are set to a very minimal value and the DCGM check is too strict. Even small BER values get flagged, so downgrade the BER detection to warning. At a later point a specific threshold can be configured.

New nvlink based health based on newer dcgm versions are also added.