### PR TITLE
Make HealthStatus orderable.

### DIFF
--- a/healthagent/bindings.py
+++ b/healthagent/bindings.py
@@ -271,7 +271,7 @@ class Wrap:
     @classmethod
     def convert_health_to_status(cls, health):
         """
-        helper method to convert helath return to a string for display purpose
+        helper method to convert health return to a string for display purpose
         """
         if health == dcgm_structs.DCGM_HEALTH_RESULT_PASS:
             return HealthStatus.OK

--- a/healthagent/gpu.py
+++ b/healthagent/gpu.py
@@ -147,49 +147,50 @@ class GpuHealthChecks(HealthModule):
             vd[gpuid] = {}
 
         info = vd[gpuid]
-        status = HealthStatus.ERROR
         if condition == dcgm_structs.DCGM_POLICY_COND_DBE:
             if 'location' not in info:
                 info['location'] = set()
             info['location'].add(next(key for key, value in dcgm_structs.c_dcgmPolicyConditionDbe_t.LOCATIONS.items() if value == callbackresp.val.dbe.location))
             info['numerrors'] = callbackresp.val.dbe.numerrors
             info['details'] = f"Double-Bit ECC errors({info['numerrors']}) found at location: {info['location']} on GPU: {gpuid}"
+            report.escalate(HealthStatus.ERROR)
         elif condition == dcgm_structs.DCGM_POLICY_COND_PCI:
             info['replay_count'] = callbackresp.val.pci.counter
             info['details'] = f"PCI replay count({info['replay_count']}) on GPU: {gpuid}"
+            report.escalate(HealthStatus.ERROR)
         elif condition == dcgm_structs.DCGM_POLICY_COND_NVLINK:
             info['error_count'] = callbackresp.val.nvlink.counter
             if 'field_id' not in info:
                 info['field_id'] = set()
             info['field_id'].add(callbackresp.val.nvlink.fieldId)
             info['details'] = f"Nvlink violation on GPU: {gpuid}"
+            report.escalate(HealthStatus.ERROR)
         elif condition == dcgm_structs.DCGM_POLICY_COND_XID:
             if 'xid_error' not in info:
                 info['xid_error'] = set()
             info['xid_error'].add(callbackresp.val.xid.errnum)
             info['details'] = f"XID errors found: XID {info['xid_error']} on GPU {gpuid}"
-            # Check if all XIDs are harmless - if so, downgrade to warning
+            # Harmless XIDs are warnings; others are errors
             if info['xid_error'].issubset(set(harmless_xid)):
-                status = HealthStatus.WARNING
+                report.escalate(HealthStatus.WARNING)
             else:
-                status = HealthStatus.ERROR
+                report.escalate(HealthStatus.ERROR)
         # elif condition == dcgm_structs.DCGM_POLICY_COND_THERMAL:
-        #     status = HealthStatus.WARNING
+        #     report.escalate(HealthStatus.WARNING)
         #     info['temperature'] = callbackresp.val.thermal.thermalViolation
         #     info['details'] = f"Thermal violation detected: Temperature reached {info['temperature']} Celsius GPU: {gpuid}"
         # elif condition == dcgm_structs.DCGM_POLICY_COND_POWER:
-        #     status = HealthStatus.WARNING
+        #     report.escalate(HealthStatus.WARNING)
         #     info['power'] = callbackresp.val.power.powerViolation
         #     info['details'] = f"Power violation detected: Power draw {info['power']} Watts GPU: {gpuid}"
         elif condition == dcgm_structs.DCGM_POLICY_COND_MAX_PAGES_RETIRED:
             info['sbepage_count'] = callbackresp.val.mpr.sbepages
             info['dbepage_count'] = callbackresp.val.mpr.dbepages
             info['details'] = f"Max retired pages violation: SBE retired pages: {info['sbepage_count']}, DBE retired pages {info['dbepage_count']} GPU: {gpuid}"
+            report.escalate(HealthStatus.ERROR)
 
         vd[gpuid] = info
         report.custom_fields[condition_str] = vd
-
-        report.status = status
         report.description = "GPU Policy Violations detected"
         if not report.details:
             report.details = info['details']
@@ -305,7 +306,7 @@ class GpuHealthChecks(HealthModule):
             try:
                 details = list()
                 subsystems = set()
-                status = HealthStatus.OK
+                report = HealthReport()
                 if not self.dcgmGroup:
                     raise Wrap.DcgmInvalidHandle
                 group_health = self.dcgmGroup.health.Check()
@@ -313,9 +314,8 @@ class GpuHealthChecks(HealthModule):
 
                 field_errors, category = self.track_fields()
                 if len(field_errors) > 0:
-                    status = HealthStatus.ERROR
-                if status == HealthStatus.OK and incident_count == 0:
-                    report = HealthReport()
+                    report.escalate(HealthStatus.ERROR)
+                if report.status == HealthStatus.OK and incident_count == 0:
                     await self.reporter.update_report(name=health_system, report=report)
                     return
 
@@ -324,29 +324,25 @@ class GpuHealthChecks(HealthModule):
                     system = Wrap.convert_system_enum_to_system_name(group_health.incidents[index].system)
                     error_code = group_health.incidents[index].error.code
                     if error_code == dcgm_errors.DCGM_FR_NVLINK_EFFECTIVE_BER_THRESHOLD:
-                        if status != HealthStatus.ERROR:
-                            status = HealthStatus.WARNING
+                        report.escalate(HealthStatus.WARNING)
                     else:
                         incident_status = Wrap.convert_health_to_status(group_health.incidents[index].health)
                         if incident_status == HealthStatus.NA:
                             log.error(f"Invalid health status receieved {system}, {error_code}")
-                        elif incident_status == HealthStatus.ERROR:
-                            status = HealthStatus.ERROR
-                        elif incident_status == HealthStatus.WARNING and status != HealthStatus.ERROR:
-                            status = HealthStatus.WARNING
+                        elif incident_status != HealthStatus.NA:
+                            report.escalate(incident_status)
                     subsystems.add(system)
                     details.append(group_health.incidents[index].error.msg)
 
                 details.extend(field_errors)
                 subsystems.update(category)
                 incident_count += len(field_errors)
-                description = f"{health_system} report {status.value} count={incident_count} subsystem={', '.join(subsystems)}"
+                description = f"{health_system} report {report.status.value} count={incident_count} subsystem={', '.join(subsystems)}"
                 custom_fields['categories'] = subsystems
                 custom_fields['error_count'] = incident_count
-                report = HealthReport(status=status,
-                                      description=description,
-                                      details='\n'.join(details),
-                                      custom_fields=custom_fields)
+                report.description = description
+                report.details = '\n'.join(details)
+                report.custom_fields = custom_fields
                 await self.reporter.update_report(name=health_system, report=report)
                 return
 

--- a/healthagent/network.py
+++ b/healthagent/network.py
@@ -236,15 +236,14 @@ class NetworkHealthChecks(HealthModule):
             custom_fields[ni.name]['link_flap_since_uptime'] = ni.carrier_changes
             if link_down_rate_per_hour >= 1:
                 msgs.append(f"Network interface {ni.name} went down {link_down_rate_per_hour} times in the last hour")
-                if report.status == HealthStatus.OK:
-                    report.status = HealthStatus.WARNING
+                report.escalate(HealthStatus.WARNING)
 
             if ni.operstate != OperState.UP:
                 custom_fields[ni.name]['error_count'] = 1
                 unop.append(ni.name)
                 msgs.append(f"Network interface {ni.name} is not operational and in state {ni.operstate.value}.")
                 custom_fields[ni.name]['carrier'] = ni.carrier.value
-                report.status = HealthStatus.ERROR
+                report.escalate(HealthStatus.ERROR)
 
 
         if msgs:

--- a/healthagent/process.py
+++ b/healthagent/process.py
@@ -138,7 +138,7 @@ class ProcessMonitor(HealthModule):
 
         # PID space critically consumed — fork bomb aftermath or runaway leak
         if pid_usage_pct >= self.PID_SATURATION_PCT:
-            report.status = HealthStatus.ERROR
+            report.escalate(HealthStatus.ERROR)
             report.description = "Critical PID table saturation by zombie processes"
             report.recommendations = "Node Reboot required"
             msgs.append(f"Zombie processes consuming {pid_usage_pct:.1f}% of PID space "
@@ -146,14 +146,14 @@ class ProcessMonitor(HealthModule):
 
         # High zombie count relative to node size
         elif zombie_count >= self.zombie_warn_threshold:
-            report.status = HealthStatus.WARNING
+            report.escalate(HealthStatus.WARNING)
             report.description = "Zombie processes found in the pid table"
             msgs.append(f"Zombie Processes found: {zombie_count} "
                         f"(threshold: {self.zombie_warn_threshold}, "
                         f"pid_max: {self.pid_max})")
 
         if hungprocs:
-            report.status = HealthStatus.ERROR
+            report.escalate(HealthStatus.ERROR)
             msgs.append(f"Unkillable Processes found: {len(hungprocs)}")
             for pid, proc, user, wchan in hungprocs:
                 msgs.append(f"PID: {pid}\tProcess: {proc}\tUser: {user}\tBlocked on: {wchan}")

--- a/healthagent/reporter.py
+++ b/healthagent/reporter.py
@@ -31,10 +31,37 @@ def make_json_safe(obj):
         raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
 class HealthStatus(Enum):
-    OK = 'OK'
-    WARNING = 'Warning'
-    ERROR = 'Error'
-    NA = 'NA'
+    # (display_value, severity) — severity controls ordering
+    NA = ('NA', 0)
+    OK = ('OK', 1)
+    WARNING = ('Warning', 2)
+    ERROR = ('Error', 3)
+
+    def __new__(cls, display_value: str, severity: int):
+        obj = object.__new__(cls)
+        obj._value_ = display_value
+        obj.severity = severity
+        return obj
+
+    def __lt__(self, other):
+        if not isinstance(other, HealthStatus):
+            return NotImplemented
+        return self.severity < other.severity
+
+    def __le__(self, other):
+        if not isinstance(other, HealthStatus):
+            return NotImplemented
+        return self.severity <= other.severity
+
+    def __gt__(self, other):
+        if not isinstance(other, HealthStatus):
+            return NotImplemented
+        return self.severity > other.severity
+
+    def __ge__(self, other):
+        if not isinstance(other, HealthStatus):
+            return NotImplemented
+        return self.severity >= other.severity
 
 @dataclass
 class HealthReport:
@@ -71,6 +98,19 @@ class HealthReport:
 
     def __getattr__(self, item):
         return self.custom_fields.get(item, None)
+
+    def escalate(self, new_status: HealthStatus):
+        """
+        Only upgrade status, never downgrade.
+        This method is provided so that statuses can be
+        set based on different conditions and only the
+        highest status is preserved.
+        Use this method to avoid writing conditional escalation
+        logic.
+        Blanket status assignments still work.
+        """
+        if new_status > self.status:
+            self.status = new_status
 
     def view(self) -> Dict[str, Any]:
         # Convert the dataclass to a dictionary

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -5,6 +5,59 @@ import json
 from unittest.mock import patch,AsyncMock
 import enum
 
+def test_healthstatus_ordering():
+    # Severity order: NA < OK < WARNING < ERROR
+    assert HealthStatus.NA < HealthStatus.OK
+    assert HealthStatus.OK < HealthStatus.WARNING
+    assert HealthStatus.WARNING < HealthStatus.ERROR
+
+    assert HealthStatus.ERROR > HealthStatus.WARNING
+    assert HealthStatus.WARNING > HealthStatus.OK
+    assert HealthStatus.OK > HealthStatus.NA
+
+    assert HealthStatus.OK >= HealthStatus.OK
+    assert HealthStatus.ERROR >= HealthStatus.WARNING
+    assert HealthStatus.OK <= HealthStatus.WARNING
+
+    # max() picks the most severe
+    assert max(HealthStatus.OK, HealthStatus.ERROR) == HealthStatus.ERROR
+    assert max(HealthStatus.WARNING, HealthStatus.OK) == HealthStatus.WARNING
+    assert max(HealthStatus.NA, HealthStatus.OK) == HealthStatus.OK
+
+
+def test_healthstatus_enum_lookups():
+    # Reverse value lookup works
+    assert HealthStatus('OK') is HealthStatus.OK
+    assert HealthStatus('Error') is HealthStatus.ERROR
+    # Name-based lookup works
+    assert HealthStatus['WARNING'] is HealthStatus.WARNING
+    # .value returns the display string, not the tuple
+    assert HealthStatus.OK.value == 'OK'
+    assert HealthStatus.ERROR.value == 'Error'
+
+
+def test_healthreport_escalate():
+    report = HealthReport()
+    assert report.status == HealthStatus.OK
+    # escalate to WARNING
+    report.escalate(HealthStatus.WARNING)
+    assert report.status == HealthStatus.WARNING
+    # escalate to ERROR
+    report.escalate(HealthStatus.ERROR)
+    assert report.status == HealthStatus.ERROR
+    # attempting to "downgrade" to WARNING is ignored
+    report.escalate(HealthStatus.WARNING)
+    assert report.status == HealthStatus.ERROR
+    # attempting to "downgrade" to OK is ignored
+    report.escalate(HealthStatus.OK)
+    assert report.status == HealthStatus.ERROR
+    # Test blanket assignments, these should still work
+    report.status = HealthStatus.WARNING
+    assert report.status == HealthStatus.WARNING
+    report.status = HealthStatus.OK
+    assert report.status == HealthStatus.OK
+
+
 def test_healthreport():
 
     ok_report =  HealthReport()


### PR DESCRIPTION
Healthstatus can now be numerically compared against
other status values. Earlier the only comparison possible
was "equals to" or "not equals to". Now we can do ">", ">="
"<" and "<=". This further allows us to write an escalate
function.
Adds an escalate function to HealthReport to avoid
having to write escalation logic in various healthchecks.
Escalate function always preserves the highest HealthStatus.