### PR TITLE
Add memory allocation check.

### DIFF
--- a/healthagent/gpu.py
+++ b/healthagent/gpu.py
@@ -249,6 +249,41 @@ class GpuHealthChecks(HealthModule):
             log.exception(e)
 
     @epilog
+    async def memory_allocation_test(self, gpu_id: list = None):
+        health_system = "MemoryAllocationTest"
+        report = HealthReport()
+        script = os.path.join(os.path.dirname(__file__), "tools", "cuda_malloc.py")
+        cmd = [sys.executable, script]
+        if gpu_id:
+            cmd.extend(["--gpus", ",".join(str(g) for g in gpu_id)])
+        try:
+            proc = await Scheduler.add_task(Scheduler.subprocess(*cmd))
+            stdout, stderr = await proc.communicate()
+            output = stdout.decode().strip()
+            err_output = stderr.decode().strip()
+            if proc.returncode == 0:
+                report.status = HealthStatus.OK
+                report.description = "Memory allocation test passed"
+                report.details = output
+            elif proc.returncode == 2:
+                report.status = HealthStatus.WARNING
+                report.description = "Test not run"
+                report.details = err_output or output
+            else:
+                report.status = HealthStatus.ERROR
+                report.description = "Memory allocation test failed"
+                report.details = f"{output}\n{err_output}".strip()
+        except Exception as e:
+            log.exception(e)
+            report.status = HealthStatus.WARNING
+            report.description = "Test not run."
+            report.details = str(e)
+        await self.reporter.update_report(name=health_system, report=report)
+        response = {}
+        response[health_system] = report.view()
+        return response
+
+    @epilog
     async def run_epilog(self):
         health_system = f"ActiveGPUHealthChecks"
         report = await Scheduler.add_task(run_active_healthchecksv2)

--- a/healthagent/tools/cuda_malloc.py
+++ b/healthagent/tools/cuda_malloc.py
@@ -1,0 +1,53 @@
+import argparse, sys
+
+try:
+    from cuda.bindings import runtime as cudart
+except ImportError:
+    print("cuda.bindings not available, skipping memory allocation test", file=sys.stderr)
+    sys.exit(2)
+
+
+def check(result):
+    if result[0] != cudart.cudaError_t.cudaSuccess:
+        raise RuntimeError(f"CUDA error: {cudart.cudaGetErrorString(result[0])[1]}")
+    return result[1] if len(result) == 2 else result[1:]
+
+
+def allocate_on_gpu(gpu_id: int, pct: float) -> None:
+    check(cudart.cudaSetDevice(gpu_id))
+    total = check(cudart.cudaMemGetInfo())[1]
+    size = int(total * pct / 100)
+    ptr = None
+    try:
+        ptr = check(cudart.cudaMalloc(size))
+        check(cudart.cudaMemset(ptr, 0xAB, size))
+    finally:
+        if ptr is not None:
+            # Best effort, dont mask original exception
+            cudart.cudaFree(ptr)
+    print(f"  GPU {gpu_id}: {total / 1e9:.2f} GB total, allocated {pct}% ({size / 1e9:.2f} GB) - OK")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pct", type=float, default=95, help="Percent of total GPU memory (default: 95)")
+    parser.add_argument("--gpus", type=str, default=None, help="Comma-separated GPU IDs (default: all)")
+    args = parser.parse_args()
+
+    if args.pct <= 0 or args.pct >= 100:
+        parser.error(f"--pct must be between 0 and 100 exclusive, got {args.pct}")
+
+    test_name = "Memory Allocation test"
+    gpu_count = check(cudart.cudaGetDeviceCount())
+    gpu_ids = [int(g) for g in args.gpus.split(",")] if args.gpus else list(range(gpu_count))
+    print(f"Found {gpu_count} GPU(s), testing {gpu_ids} at {args.pct}%\n")
+
+    failures = []
+    for gpu in gpu_ids:
+        try:
+            allocate_on_gpu(gpu, args.pct)
+        except RuntimeError as e:
+            failures.append(f"{test_name} failed on GPU {gpu}: {e}")
+    if failures:
+        print("\n".join(failures), file=sys.stderr)
+        sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ name = "healthagent"
 version = "1.0.6"
 dependencies = ["dbus-next", "systemd-python", "pytest-asyncio"]
 
+[project.optional-dependencies]
+gpu = ["cuda-bindings"]
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
@@ -20,7 +23,7 @@ healthagent-install = "healthagent.install:main"
 include-package-data = true
 
 [tool.setuptools.package-data]
-healthagent = ["logging.conf", "etc/*"]
+healthagent = ["logging.conf", "etc/*", "tools/*"]
 
 [tool.setuptools.packages.find]
 include = ["healthagent"]

--- a/specs/default/cluster-init/scripts/00-install.sh
+++ b/specs/default/cluster-init/scripts/00-install.sh
@@ -221,6 +221,11 @@ mkdir -p $HEALTHAGENT_DIR
     if [ -e "/dev/nvidia0" ]; then
         echo "NVIDIA GPU is present"
         setup_dcgm
+        source $VENV_DIR/bin/activate
+        if ! pip install cuda-bindings; then
+            echo "WARNING: Failed to install cuda-bindings"
+        fi
+        deactivate
     fi
     setup_systemd
     echo "HEALTHAGENT_INSTALLED_VERSION=$HEALTHAGENT_VERSION" > $HEALTHAGENT_DIR/.install


### PR DESCRIPTION
DCGM's memory allocation check does not reliably give a PASS/FAIL result. Check succeeds on VM's where memory is allocated.

This adds our own memory allocation check and uses cuda bindings in python.