### PR TITLE
Refactor to allow cli to list and execute specific checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build/
 .build.log
 .venv/
 .bindings
+*.pyc
+.context/

--- a/healthagent/__init__.py
+++ b/healthagent/__init__.py
@@ -1,3 +1,13 @@
+def healthcheck(name):
+    """Declare a function as a named healthcheck.
+    The name is the report key visible in `health -s` output and
+    can be targeted by using `-c/--check <name>` with `health -e` / `health -p`.
+    """
+    def decorator(func):
+        func.report_name = name
+        return func
+    return decorator
+
 def epilog(func):
     func.epilog = True
     return func

--- a/healthagent/__init__.py
+++ b/healthagent/__init__.py
@@ -1,10 +1,17 @@
-def healthcheck(name):
+def healthcheck(name, args=None, description=None):
     """Declare a function as a named healthcheck.
     The name is the report key visible in `health -s` output and
     can be targeted by using `-c/--check <name>` with `health -e` / `health -p`.
+
+    Args:
+        name: Report key name.
+        args: Optional list of user-facing argument names (e.g. ["gpu_id"]).
+        description: Optional short description. Falls back to the function's docstring.
     """
     def decorator(func):
         func.report_name = name
+        func.healthcheck_args = args or []
+        func.healthcheck_description = description
         return func
     return decorator
 

--- a/healthagent/async_systemd.py
+++ b/healthagent/async_systemd.py
@@ -115,7 +115,7 @@ class SystemdMonitor(HealthModule):
 
             self.state[service] = active_state
 
-    @healthcheck("SystemdServiceCheck")
+    @healthcheck("SystemdServiceCheck", description="Track systemd service health")
     async def _update_services(self):
         """Build a single aggregated HealthReport from all tracked service states."""
         failed_services = [svc for svc, state in self.state.items() if state == "failed"]

--- a/healthagent/async_systemd.py
+++ b/healthagent/async_systemd.py
@@ -16,6 +16,8 @@ class SystemdMonitor(HealthModule):
     Monitors the state of systemd services and reports unhealthy services based on their state.
     Purpose of this healthcheck is NOT to report any errors in a systemd service but only when the service reaches
     a failed state or recovers from the failed state.
+
+    documentation: https://www.freedesktop.org/wiki/Software/systemd/dbus/
     """
 
     def __init__(self, reporter: Reporter):
@@ -113,7 +115,6 @@ class SystemdMonitor(HealthModule):
                     self.state[service] = active_state
                     await self._update_services()
 
-            self.state[service] = active_state
 
     @healthcheck("SystemdServiceCheck", description="Track systemd service health")
     async def _update_services(self):

--- a/healthagent/async_systemd.py
+++ b/healthagent/async_systemd.py
@@ -2,7 +2,9 @@ from dbus_next.aio import MessageBus
 from dbus_next.errors import DBusError
 from dbus_next.constants import BusType
 import logging
+from datetime import datetime, timezone
 import systemd.journal
+from healthagent import healthcheck
 from healthagent.healthmodule import HealthModule
 from healthagent.scheduler import Scheduler
 from healthagent.reporter import Reporter, HealthReport, HealthStatus
@@ -100,21 +102,51 @@ class SystemdMonitor(HealthModule):
         transient or do not represent valid recovery from an unhealthy state.
         """
         log.debug(f"service: {service}, ActiveState: {active_state} SubState: {substate}")
-        report = HealthReport()
         if active_state != self.state.get(service):
             if active_state == "failed":
-                report.status =  HealthStatus.ERROR
-                report.description = f"{service} Service unhealthy"
-                report.details = self.get_journal_entries(service_name=service)
-                log.error(report.description)
-                await self.reporter.update_report(name=service, report=report)
+                log.error(f"{service} Service unhealthy")
+                self.state[service] = active_state
+                await self._update_services()
             elif active_state == "active" and substate == "running":
-                if self.state.get(service) in ("failed", "inactive"):
+                if self.state.get(service) in ("failed", "inactive", None):
                     log.info(f"{service} Service Healthy")
-                    report.status = HealthStatus.OK
-                    await self.reporter.update_report(name=service, report=report)
+                    self.state[service] = active_state
+                    await self._update_services()
 
             self.state[service] = active_state
+
+    @healthcheck("SystemdServiceCheck")
+    async def _update_services(self):
+        """Build a single aggregated HealthReport from all tracked service states."""
+        failed_services = [svc for svc, state in self.state.items() if state == "failed"]
+        now = datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S %Z")
+        DETAIL_SEPARATOR = "------"
+        # Build per-service custom_fields
+        custom_fields = {"error_count": len(failed_services)}
+        for svc, state in self.state.items():
+            svc_status = HealthStatus.ERROR if state == "failed" else HealthStatus.OK
+            custom_fields[svc] = {"status": svc_status.value, "last_update": now}
+
+        if failed_services:
+            description = ", ".join(failed_services) + " unhealthy"
+            details_parts = []
+            for svc in failed_services:
+                journal = self.get_journal_entries(service_name=svc)
+                details_parts.append(f"{DETAIL_SEPARATOR} {svc} {DETAIL_SEPARATOR}\n{journal}")
+            details = "\n".join(details_parts)
+            report = HealthReport(
+                status=HealthStatus.ERROR,
+                description=description,
+                details=details,
+                custom_fields=custom_fields,
+            )
+        else:
+            report = HealthReport(
+                status=HealthStatus.OK,
+                custom_fields=custom_fields,
+            )
+
+        await self.reporter.update_report(name=self._update_services.report_name, report=report)
 
 
     def create_callback(self, unit: str = None, service_name: str = None):

--- a/healthagent/client.py
+++ b/healthagent/client.py
@@ -96,7 +96,14 @@ def print_checks_table(response, check_type="all"):
                 continue
             category = ", ".join(categories)
             interval = info.get("interval")
-            interval_str = f"{interval}s" if interval is not None else ""
+            if isinstance(interval, int) and interval > 0:
+                interval_str = f"{interval}s"
+            elif interval == -1:
+                interval_str = "-1"
+            elif interval == "async":
+                interval_str = "async"
+            else:
+                interval_str = ""
             sig = info.get("signature", "")
             rows.append((module, name, category, interval_str, sig))
 

--- a/healthagent/client.py
+++ b/healthagent/client.py
@@ -104,14 +104,15 @@ def print_checks_table(response, check_type="all"):
                 interval_str = "async"
             else:
                 interval_str = ""
-            sig = info.get("signature", "")
-            rows.append((module, name, category, interval_str, sig))
+            args_str = ", ".join(info.get("args", []))
+            desc = info.get("description", "")
+            rows.append((module, name, category, interval_str, args_str, desc))
 
     if not rows:
         print("No checks found.")
         return
 
-    headers = ("Module", "Check", "Category", "Interval", "Signature")
+    headers = ("Module", "Check", "Category", "Interval", "Args", "Description")
     col_widths = [len(h) for h in headers]
     for row in rows:
         for i, val in enumerate(row):

--- a/healthagent/client.py
+++ b/healthagent/client.py
@@ -15,8 +15,8 @@ def get_response(command, timeout):
             # Connect to the Unix socket
             client_socket.connect(SOCKET_PATH)
 
-            # Prepare the message
-            client_socket.sendall(command.encode())
+            # Always send JSON
+            client_socket.sendall(json.dumps(command).encode())
             client_socket.shutdown(socket.SHUT_WR)
             # Now wait for full response
             response = b''
@@ -45,6 +45,35 @@ def get_response(command, timeout):
         logging.error(f"An unexpected error occurred: {e}")
         return None
 
+def parse_check_args(check_groups):
+    """Parse -c groups into a checks dict.
+
+    Each group is a list of strings: [check_name, key=value, ...]
+
+    Returns:
+        dict or None: {check_name: {key: value, ...}, ...} or None if no checks specified.
+    """
+    if not check_groups:
+        return None
+    checks = {}
+    for group in check_groups:
+        if not group:
+            continue
+        check_name = group[0]
+        kwargs = {}
+        for arg in group[1:]:
+            if '=' in arg:
+                key, _, value = arg.partition('=')
+                # Comma-separated values become a list
+                if ',' in value:
+                    value = value.split(',')
+                kwargs[key] = value
+            else:
+                logging.error(f"Invalid argument '{arg}' for check '{check_name}'. Expected key=value format.")
+                sys.exit(1)
+        checks[check_name] = kwargs
+    return checks if checks else None
+
 def print_bash_friendly(result):
 
     res = {}
@@ -56,6 +85,36 @@ def print_bash_friendly(result):
         )
         res[module_name] = total_errors
     return [print(f"{x},{y}") for x,y in res.items()]
+
+def print_checks_table(response, check_type="all"):
+    """Format list_checks response as a table, optionally filtered by type."""
+    rows = []
+    for module, checks in response.items():
+        for name, info in checks.items():
+            categories = info.get("category", [])
+            if check_type != "all" and check_type not in categories:
+                continue
+            category = ", ".join(categories)
+            interval = info.get("interval")
+            interval_str = f"{interval}s" if interval is not None else ""
+            sig = info.get("signature", "")
+            rows.append((module, name, category, interval_str, sig))
+
+    if not rows:
+        print("No checks found.")
+        return
+
+    headers = ("Module", "Check", "Category", "Interval", "Signature")
+    col_widths = [len(h) for h in headers]
+    for row in rows:
+        for i, val in enumerate(row):
+            col_widths[i] = max(col_widths[i], len(val))
+
+    fmt = "  ".join(f"{{:<{w}}}" for w in col_widths)
+    print(fmt.format(*headers))
+    print(fmt.format(*("-" * w for w in col_widths)))
+    for row in rows:
+        print(fmt.format(*row))
 
 def run_command(command, timeout, bash=False):
     response = get_response(command=command, timeout=timeout)
@@ -83,35 +142,54 @@ def main():
     group.add_argument(
         "-v", "--version", action="store_true", help="Return Healthagent version"
     )
+    group.add_argument(
+        "-l", "--list-checks", metavar="TYPE", nargs="?", const="all",
+        choices=["all", "epilog", "prolog"],
+        help="List available checks by type (default: all). Example: health -l epilog"
+    )
 
+    parser.add_argument(
+        "-c", "--check", action="append", nargs="+", metavar="NAME",
+        help="Run a prolog/epilog check by name, with optional key=value args. "
+             "Repeatable. Example: -c GpuMemoryCheck gpu_id=0,1 -c GpuDiagnosticCheck"
+    )
     parser.add_argument("-b", "--bash", action="store_true", default=False, help="Export results into bash friendly variables")
-    #parser.add_argument(
-    #    "-l", "--log-level", help="Logging level (e.g., DEBUG, INFO, WARNING, ERROR, CRITICAL)"
-    #)
 
     args = parser.parse_args()
 
-    # Configure logging level
-    #log_level = args.log_level.upper() if args.log_level else "ERROR"
-    #if log_level not in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:
-    #    log_level = "ERROR"
     logging.basicConfig(
         format='%(levelname)s - %(message)s',
         level=logging.ERROR
-        #level=getattr(logging, log_level, logging.ERROR)
         )
 
-    if not (args.epilog or args.prolog or args.version):
+    if not (args.epilog or args.prolog or args.version or args.list_checks):
         args.status = True
-    # Handle arguments
-    if args.epilog:
-        run_command(command="epilog", timeout=1200)
+
+    checks = parse_check_args(args.check)
+
+    if checks and not (args.epilog or args.prolog):
+        parser.error("-c/--check can only be used with -e/--epilog or -p/--prolog")
+
+    if args.list_checks:
+        command = {"command": "list_checks", "type": "all"}
+        response = get_response(command=command, timeout=10)
+        if not response:
+            sys.exit(-1)
+        print_checks_table(response, check_type=args.list_checks)
+    elif args.epilog:
+        command = {"command": "epilog"}
+        if checks:
+            command["checks"] = checks
+        run_command(command=command, timeout=1200)
     elif args.prolog:
-        pass
+        command = {"command": "prolog"}
+        if checks:
+            command["checks"] = checks
+        run_command(command=command, timeout=1200)
     elif args.status:
-        run_command(command="status", timeout=30, bash=args.bash)
+        run_command(command={"command": "status"}, timeout=30, bash=args.bash)
     elif args.version:
-        run_command(command="version", timeout=5)
+        run_command(command={"command": "version"}, timeout=5)
     else:
         parser.print_help()
 

--- a/healthagent/gpu.py
+++ b/healthagent/gpu.py
@@ -1,16 +1,12 @@
 import asyncio
 import sys
-import json
-import time
 import logging
 import os
-from time import time
 import shutil
 from datetime import datetime
 from healthagent import epilog,status,healthcheck
 from healthagent.scheduler import Scheduler
 from healthagent.healthmodule import HealthModule
-from dataclasses import asdict
 from healthagent.reporter import Reporter, HealthReport,HealthStatus
 from healthagent.bindings import *
 
@@ -364,7 +360,7 @@ class GpuHealthChecks(HealthModule):
             try:
                 self.setup()
             except Wrap.DcgmConnectionFail as e:
-                log.critical("Unable to connect to DCGM: {e}")
+                log.critical(f"Unable to connect to DCGM: {e}")
                 log.critical("To re-instantiate checks, restart the nvidia-dcgm service.")
             else:
                 log.info("Re-initialized our connection to DCGM.")

--- a/healthagent/gpu.py
+++ b/healthagent/gpu.py
@@ -7,7 +7,7 @@ import os
 from time import time
 import shutil
 from datetime import datetime
-from healthagent import epilog,status
+from healthagent import epilog,status,healthcheck
 from healthagent.scheduler import Scheduler
 from healthagent.healthmodule import HealthModule
 from dataclasses import asdict
@@ -102,6 +102,7 @@ class GpuHealthChecks(HealthModule):
             log.debug("Power Limit : %s" % (Wrap.convert_value_to_string(self.gpu_config[x].mPowerLimit.val)))
             log.debug("Compute Mode: %s" % (Wrap.convert_value_to_string(self.gpu_config[x].mComputeMode)))
 
+    @healthcheck("GpuCountCheck")
     @Scheduler.periodic(120)
     async def gpu_count_check(self):
 
@@ -112,7 +113,7 @@ class GpuHealthChecks(HealthModule):
             report.status = HealthStatus.ERROR
             report.details = f"OS shows {os_gpu_count} GPU devices, PCI Bus shows {pci_gpu_count} GPU devices"
             report.description = "GPU Count Mismatch"
-        await self.reporter.update_report(name="GPUCountMismatch", report=report)
+        await self.reporter.update_report(name=self.gpu_count_check.report_name, report=report)
 
     async def create(self):
         await self.reporter.clear_all_errors()
@@ -120,9 +121,10 @@ class GpuHealthChecks(HealthModule):
         Scheduler.add_task(self.gpu_count_check)
         Scheduler.add_task(self.run_background_healthchecks)
 
+    @healthcheck("GpuPolicyCheck")
     async def handle_policy_violation(self, callbackresp):
 
-        health_system = "GPUPolicyChecks"
+        health_system = self.handle_policy_violation.report_name
         report = self.reporter.get_report(health_system) or HealthReport()
         condition = callbackresp.condition
         gpuid = callbackresp.gpuId
@@ -249,9 +251,10 @@ class GpuHealthChecks(HealthModule):
         except Exception as e:
             log.exception(e)
 
+    @healthcheck("GpuMemoryCheck")
     @epilog
     async def memory_allocation_test(self, gpu_id: list = None):
-        health_system = "MemoryAllocationTest"
+        health_system = self.memory_allocation_test.report_name
         report = HealthReport()
         script = os.path.join(os.path.dirname(__file__), "tools", "cuda_malloc.py")
         cmd = [sys.executable, script]
@@ -284,15 +287,17 @@ class GpuHealthChecks(HealthModule):
         response[health_system] = report.view()
         return response
 
+    @healthcheck("GpuDiagnosticCheck")
     @epilog
     async def run_epilog(self):
-        health_system = f"ActiveGPUHealthChecks"
+        health_system = self.run_epilog.report_name
         report = await Scheduler.add_task(run_active_healthchecksv2)
         await self.reporter.update_report(name=health_system, report=report)
         response = {}
         response[health_system] = report.view()
         return response
 
+    @healthcheck("GpuHealthCheck")
     @Scheduler.periodic(60)
     async def run_background_healthchecks(self):
         """
@@ -300,7 +305,7 @@ class GpuHealthChecks(HealthModule):
         These are safe to run constantly alongside jobs.
         """
 
-        health_system = f"BackgroundGPUHealthChecks"
+        health_system = self.run_background_healthchecks.report_name
         custom_fields = {}
         try:
             try:

--- a/healthagent/gpu.py
+++ b/healthagent/gpu.py
@@ -102,7 +102,7 @@ class GpuHealthChecks(HealthModule):
             log.debug("Power Limit : %s" % (Wrap.convert_value_to_string(self.gpu_config[x].mPowerLimit.val)))
             log.debug("Compute Mode: %s" % (Wrap.convert_value_to_string(self.gpu_config[x].mComputeMode)))
 
-    @healthcheck("GpuCountCheck")
+    @healthcheck("GpuCountCheck", description="Check OS vs PCI GPU count")
     @Scheduler.periodic(120)
     async def gpu_count_check(self):
 
@@ -121,7 +121,7 @@ class GpuHealthChecks(HealthModule):
         Scheduler.add_task(self.gpu_count_check)
         Scheduler.add_task(self.run_background_healthchecks)
 
-    @healthcheck("GpuPolicyCheck")
+    @healthcheck("GpuPolicyCheck", description="GPU policy violation checks")
     async def handle_policy_violation(self, callbackresp):
 
         health_system = self.handle_policy_violation.report_name
@@ -251,7 +251,7 @@ class GpuHealthChecks(HealthModule):
         except Exception as e:
             log.exception(e)
 
-    @healthcheck("GpuMemoryCheck")
+    @healthcheck("GpuMemoryCheck", args=["gpu_id"], description="Run GPU memory allocation test. Args: gpu_id=0,1")
     @epilog
     async def memory_allocation_test(self, gpu_id: list = None):
         health_system = self.memory_allocation_test.report_name
@@ -287,7 +287,7 @@ class GpuHealthChecks(HealthModule):
         response[health_system] = report.view()
         return response
 
-    @healthcheck("GpuDiagnosticCheck")
+    @healthcheck("GpuDiagnosticCheck", description="Run dcgm diagnostics checks")
     @epilog
     async def run_epilog(self):
         health_system = self.run_epilog.report_name
@@ -297,7 +297,7 @@ class GpuHealthChecks(HealthModule):
         response[health_system] = report.view()
         return response
 
-    @healthcheck("GpuHealthCheck")
+    @healthcheck("GpuHealthCheck", description="Periodic GPU health monitoring")
     @Scheduler.periodic(60)
     async def run_background_healthchecks(self):
         """

--- a/healthagent/healthagent.py
+++ b/healthagent/healthagent.py
@@ -102,11 +102,20 @@ class Healthagent:
 
 
     @classmethod
-    async def _execute_module_functions(cls, attribute_flag: str):
+    async def _execute_module_functions(cls, attribute_flag: str, checks: dict = None):
         response = {}
         for name, module in cls.modules.items():
-            response[name] = await module.execute(attribute_flag)
+            response[name] = await module.execute(attribute_flag, checks=checks)
         return response
+
+    @classmethod
+    def _list_module_checks(cls, attribute_flag: str = None):
+        result = {}
+        for name, module in cls.modules.items():
+            module_checks = module.list_checks(attribute_flag)
+            if module_checks:
+                result[name] = module_checks
+        return result
 
     @classmethod
     async def handle_client(cls, reader, writer):
@@ -121,27 +130,31 @@ class Healthagent:
                 data += chunk
             message = data.decode()
             log.debug("Received: %s", message)
+
+            request = json.loads(message)
+            start = perf_counter()
+            command = request.get("command", "")
+            checks = request.get("checks", None)
+
             response = {}
-            if message == "epilog":
-                log.debug("Received epilog request")
-                response = await cls._execute_module_functions(attribute_flag="epilog")
-                log.debug(f"epilog response: {response}")
-            elif message == "prolog":
-                log.debug("Received Prolog request")
-                response = await cls._execute_module_functions(attribute_flag="prolog")
-                log.debug(f"prolog response {response}")
-            elif message == "status":
-                log.debug("Received status request")
+            if command == "epilog":
+                response = await cls._execute_module_functions(attribute_flag="epilog", checks=checks)
+            elif command == "prolog":
+                response = await cls._execute_module_functions(attribute_flag="prolog", checks=checks)
+            elif command == "status":
                 response = await cls._execute_module_functions(attribute_flag="status")
-                log.debug(f"status response: {response}")
-            elif message == "version":
+            elif command == "list_checks":
+                check_type = request.get("type", "all")
+                flag = None if check_type == "all" else check_type
+                response = cls._list_module_checks(attribute_flag=flag)
+            elif command == "version":
                 response = VERSION
-                log.debug(f"version response: {response}")
             else:
                 raise ValueError("Invalid message received")
 
             writer.write(json.dumps(response).encode())
             await writer.drain()
+            log.debug(f"{command} Response sent successfully in {perf_counter() - start:.4f} sec")
         except Exception as e:
             log.exception(e)
         writer.close()

--- a/healthagent/healthmodule.py
+++ b/healthagent/healthmodule.py
@@ -11,6 +11,7 @@ class HealthModule(ABC):
     Base health module class. Extend this to implement specific health checks.
         - Override `create` for async initialization (e.g. background tasks, connections).
         - Override `status` for custom health status logic. By default, it summarizes the reporter.
+        - Decorate methods with `@healthcheck("Name")` to declare their report name.
         - Decorate methods with `@status` to include their output in the health status response
         - Decorate methods with `@epilog` and/or `@prolog` to include their output in the epilog and/or prolog response (if implemented) respectively.
 
@@ -19,6 +20,7 @@ class HealthModule(ABC):
     def __init__(self, reporter: Reporter):
         self.reporter = reporter
         self._handler_cache = {}
+        self._checks_registry = None
 
     async def create(self):
         """Async initialization. Override to register background tasks, open connections, etc."""
@@ -27,7 +29,16 @@ class HealthModule(ABC):
     @status
     def status(self) -> dict:
         """Return current health status. Override if custom status logic is needed."""
+        self._prune_stale_reports()
         return self.reporter.summarize()
+
+    def _prune_stale_reports(self):
+        """Remove reporter entries whose keys no longer match any registered healthcheck."""
+        valid_names = set(self._build_checks_registry().keys())
+        stale_keys = [k for k in self.reporter.store if k not in valid_names]
+        for key in stale_keys:
+            log.warning(f"Removing stale report key '{key}' (no matching healthcheck)")
+            del self.reporter.store[key]
 
     def _get_handlers(self, attribute_flag: str) -> list:
         """
@@ -46,12 +57,97 @@ class HealthModule(ABC):
             self._handler_cache[attribute_flag] = handlers
         return self._handler_cache[attribute_flag]
 
-    async def execute(self, attribute_flag: str) -> dict:
-        """Execute all handlers for the given flag, merge results."""
+    def _build_checks_registry(self) -> dict:
+        """Discover all @healthcheck-decorated methods and classify them. Cached after first call.
+
+        Returns:
+            {report_name: {"signature": str, "category": [str], "interval": int|None}}
+        """
+        if self._checks_registry is not None:
+            return self._checks_registry
+        result = {}
+        seen_names = set()
+        for klass in type(self).__mro__:
+            for name, attr in klass.__dict__.items():
+                if name in seen_names:
+                    continue
+                report_name = getattr(attr, 'report_name', None)
+                if not report_name:
+                    continue
+                seen_names.add(name)
+                if report_name in result:
+                    log.error(f"Duplicate healthcheck report_name '{report_name}' "
+                              f"declared by '{name}' in {klass.__name__}; "
+                              f"previous entry will be overwritten")
+                handler = getattr(self, name)
+                sig = str(inspect.signature(handler))
+                interval = getattr(attr, 'interval', None)
+                categories = []
+                if getattr(attr, 'epilog', False):
+                    categories.append('epilog')
+                if getattr(attr, 'prolog', False):
+                    categories.append('prolog')
+                if interval is not None and interval > 0:
+                    categories.append('background')
+                if not categories:
+                    categories.append('async')
+                entry = {"signature": sig, "category": categories}
+                if interval is not None:
+                    entry["interval"] = interval
+                result[report_name] = entry
+        self._checks_registry = result
+        return self._checks_registry
+
+    def list_checks(self, attribute_flag: str = None) -> dict:
+        """List health checks, optionally filtered by phase.
+
+        Args:
+            attribute_flag: If provided (epilog/prolog), return only checks for that phase
+                            as {report_name: signature_str}.
+                            If None, return all checks with full metadata
+                            as {report_name: {"signature": str, "category": [str], "interval": int?}}.
+        """
+        registry = self._build_checks_registry()
+        if attribute_flag is None:
+            return registry
+        return {name: info["signature"] for name, info in registry.items()
+                if attribute_flag in info["category"]}
+
+    async def execute(self, attribute_flag: str, checks: dict = None) -> dict:
+        """Execute handlers for the given flag.
+
+        Args:
+            attribute_flag: The phase flag (epilog, prolog, status).
+            checks: Optional dict of {report_name: {kwarg: value, ...}}.
+                    If provided, only handlers whose report_name is in checks
+                    will run, and their kwargs will be passed through.
+                    Matching is case-insensitive.
+                    If None, all handlers for the flag run with no extra args.
+        """
+        # Normalize check names to lowercase for case-insensitive matching
+        checks_lower = {k.lower(): v for k, v in checks.items()} if checks is not None else None
         response = {}
         for handler in self._get_handlers(attribute_flag):
+            report_name = getattr(handler, 'report_name', None)
+            if checks_lower is not None:
+                if report_name is None or report_name.lower() not in checks_lower:
+                    continue
+                kwargs = checks_lower.get(report_name.lower(), {})
+            else:
+                kwargs = {}
             try:
-                ans = await handler() if inspect.iscoroutinefunction(handler) else handler()
+                # Pre-validate kwargs to distinguish bad caller args from handler bugs
+                if kwargs:
+                    try:
+                        inspect.signature(handler).bind(**kwargs)
+                    except TypeError as e:
+                        log.error(f"[{attribute_flag}] Invalid arguments for {handler.__name__} "
+                                  f"(report_name={report_name}): {e}")
+                        continue
+                if inspect.iscoroutinefunction(handler):
+                    ans = await handler(**kwargs)
+                else:
+                    ans = handler(**kwargs)
                 if isinstance(ans, dict):
                     response.update(ans)
                 else:

--- a/healthagent/healthmodule.py
+++ b/healthagent/healthmodule.py
@@ -61,7 +61,7 @@ class HealthModule(ABC):
         """Discover all @healthcheck-decorated methods and classify them. Cached after first call.
 
         Returns:
-            {report_name: {"signature": str, "category": [str], "interval": int|str}}
+            {report_name: {"args": [str], "description": str, "category": [str], "interval": int|str}}
               interval: positive int for periodic checks, -1 for prolog/epilog-only, "async" for on-demand.
         """
         if self._checks_registry is not None:
@@ -81,7 +81,12 @@ class HealthModule(ABC):
                               f"declared by '{name}' in {klass.__name__}; "
                               f"previous entry will be overwritten")
                 handler = getattr(self, name)
-                sig = str(inspect.signature(handler))
+                hc_args = getattr(attr, 'healthcheck_args', [])
+                hc_desc = getattr(attr, 'healthcheck_description', None)
+                if hc_desc is None:
+                    # Fall back to first line of docstring
+                    doc = getattr(handler, '__doc__', None)
+                    hc_desc = doc.strip().split('\n')[0].strip() if doc else ""
                 interval = getattr(attr, 'interval', None)
                 categories = []
                 if getattr(attr, 'epilog', False):
@@ -96,7 +101,7 @@ class HealthModule(ABC):
                 else:
                     categories.append('background')
                     entry_interval = "async"
-                entry = {"signature": sig, "category": categories, "interval": entry_interval}
+                entry = {"args": hc_args, "description": hc_desc, "category": categories, "interval": entry_interval}
                 result[report_name] = entry
         self._checks_registry = result
         return self._checks_registry
@@ -106,15 +111,36 @@ class HealthModule(ABC):
 
         Args:
             attribute_flag: If provided (epilog/prolog), return only checks for that phase
-                            as {report_name: signature_str}.
+                            as {report_name: args_str}.
                             If None, return all checks with full metadata
-                            as {report_name: {"signature": str, "category": [str], "interval": int|str}}.
+                            as {report_name: {"args": [str], "description": str, "category": [str], "interval": int|str}}.
         """
         registry = self._build_checks_registry()
         if attribute_flag is None:
             return registry
-        return {name: info["signature"] for name, info in registry.items()
+        return {name: ", ".join(info["args"]) for name, info in registry.items()
                 if attribute_flag in info["category"]}
+
+    @staticmethod
+    def _coerce_kwargs(handler, kwargs: dict) -> dict:
+        """Coerce string kwargs to match the handler's type annotations.
+
+        Converts comma-separated strings to lists when the annotation is `list`,
+        and strings to ints when the annotation is `int`.
+        """
+        if not kwargs:
+            return kwargs
+        sig = inspect.signature(handler)
+        coerced = {}
+        for key, value in kwargs.items():
+            param = sig.parameters.get(key)
+            if param and param.annotation is not inspect.Parameter.empty:
+                if param.annotation is list and isinstance(value, str):
+                    value = value.split(',')
+                elif param.annotation is int and isinstance(value, str):
+                    value = int(value)
+            coerced[key] = value
+        return coerced
 
     async def execute(self, attribute_flag: str, checks: dict = None) -> dict:
         """Execute handlers for the given flag.
@@ -139,14 +165,21 @@ class HealthModule(ABC):
             else:
                 kwargs = {}
             try:
-                # Pre-validate kwargs to distinguish bad caller args from handler bugs
+                # Filter kwargs to only allowed args declared in the decorator
                 if kwargs:
-                    try:
-                        inspect.signature(handler).bind(**kwargs)
-                    except TypeError as e:
-                        log.error(f"[{attribute_flag}] Invalid arguments for {handler.__name__} "
-                                  f"(report_name={report_name}): {e}")
-                        continue
+                    allowed_args = set(getattr(handler, 'healthcheck_args', []))
+                    if allowed_args:
+                        rejected = set(kwargs.keys()) - allowed_args
+                        if rejected:
+                            log.error(f"[{attribute_flag}] Rejected unknown args {rejected} for "
+                                      f"{handler.__name__} (report_name={report_name}). "
+                                      f"Allowed: {allowed_args}")
+                            kwargs = {k: v for k, v in kwargs.items() if k in allowed_args}
+                    else:
+                        log.error(f"[{attribute_flag}] {handler.__name__} (report_name={report_name}) "
+                                  f"does not accept user arguments. Ignoring kwargs.")
+                        kwargs = {}
+                    kwargs = self._coerce_kwargs(handler, kwargs)
                 if inspect.iscoroutinefunction(handler):
                     ans = await handler(**kwargs)
                 else:

--- a/healthagent/healthmodule.py
+++ b/healthagent/healthmodule.py
@@ -61,7 +61,8 @@ class HealthModule(ABC):
         """Discover all @healthcheck-decorated methods and classify them. Cached after first call.
 
         Returns:
-            {report_name: {"signature": str, "category": [str], "interval": int|None}}
+            {report_name: {"signature": str, "category": [str], "interval": int|str}}
+              interval: positive int for periodic checks, -1 for prolog/epilog-only, "async" for on-demand.
         """
         if self._checks_registry is not None:
             return self._checks_registry
@@ -89,11 +90,13 @@ class HealthModule(ABC):
                     categories.append('prolog')
                 if interval is not None and interval > 0:
                     categories.append('background')
-                if not categories:
-                    categories.append('async')
-                entry = {"signature": sig, "category": categories}
-                if interval is not None:
-                    entry["interval"] = interval
+                    entry_interval = interval
+                elif categories:
+                    entry_interval = -1
+                else:
+                    categories.append('background')
+                    entry_interval = "async"
+                entry = {"signature": sig, "category": categories, "interval": entry_interval}
                 result[report_name] = entry
         self._checks_registry = result
         return self._checks_registry
@@ -105,7 +108,7 @@ class HealthModule(ABC):
             attribute_flag: If provided (epilog/prolog), return only checks for that phase
                             as {report_name: signature_str}.
                             If None, return all checks with full metadata
-                            as {report_name: {"signature": str, "category": [str], "interval": int?}}.
+                            as {report_name: {"signature": str, "category": [str], "interval": int|str}}.
         """
         registry = self._build_checks_registry()
         if attribute_flag is None:

--- a/healthagent/kmsg.py
+++ b/healthagent/kmsg.py
@@ -78,7 +78,7 @@ class KmsgReader(HealthModule):
         else:
             return f"LEVEL{level}"
 
-    @healthcheck("KernelLogCheck")
+    @healthcheck("KernelLogCheck", description="Monitor kernel log for critical messages")
     def read_callback(self):
         """
         Kernel Log levels:

--- a/healthagent/kmsg.py
+++ b/healthagent/kmsg.py
@@ -1,8 +1,9 @@
 import os
 import asyncio
 import time
+from healthagent import healthcheck
 from datetime import timedelta, datetime
-from healthagent.reporter import Reporter, HealthStatus
+from healthagent.reporter import Reporter, HealthStatus, HealthReport
 from healthagent.scheduler import Scheduler
 from healthagent.healthmodule import HealthModule
 import logging
@@ -21,7 +22,6 @@ class KmsgReader(HealthModule):
             raise
         loop = asyncio.get_running_loop()
         loop.add_reader(self.fd, self.read_callback)
-        self.name = "KernelMonitor"
         Scheduler.add_task(self.clear_errors)
 
     def __del__(self):
@@ -78,6 +78,7 @@ class KmsgReader(HealthModule):
         else:
             return f"LEVEL{level}"
 
+    @healthcheck("KernelLogCheck")
     def read_callback(self):
         """
         Kernel Log levels:
@@ -86,7 +87,7 @@ class KmsgReader(HealthModule):
         KERN_ALERT  "1"
         KERN_CRIT   "2"
         """
-        report = self.reporter.get_report(name=self.name)
+        report = self.reporter.get_report(name=self.read_callback.report_name) or HealthReport()
         formatted_msg = []
         try:
             while True:
@@ -117,5 +118,4 @@ class KmsgReader(HealthModule):
             report.details = "\n".join(formatted_msg)
         report.message = "KernelMonitor Detected Alerts"
         report.description = "Kernel Log Monitor reports Critical/Emergency Alerts"
-
-        Scheduler.add_task(self.reporter.update_report, self.name, report)
+        Scheduler.add_task(self.reporter.update_report, self.read_callback.report_name, report)

--- a/healthagent/network.py
+++ b/healthagent/network.py
@@ -220,7 +220,7 @@ class NetworkHealthChecks(HealthModule):
             log.info("carrier_changes : %s" % iface.carrier_changes)
             log.info("carrier_down_count : %s" % iface.carrier_down_count)
 
-    @healthcheck("NetworkInterfaceCheck")
+    @healthcheck("NetworkInterfaceCheck", description="Monitor network interface health")
     @Scheduler.periodic(60)
     async def run_network_checks(self):
 

--- a/healthagent/network.py
+++ b/healthagent/network.py
@@ -4,7 +4,7 @@ from collections import deque, defaultdict
 from enum import Enum
 from pathlib import Path
 from dataclasses import dataclass
-from healthagent import status
+from healthagent import status, healthcheck
 from healthagent.healthmodule import HealthModule
 from healthagent.reporter import Reporter, HealthReport, HealthStatus
 from healthagent.scheduler import Scheduler
@@ -220,6 +220,7 @@ class NetworkHealthChecks(HealthModule):
             log.info("carrier_changes : %s" % iface.carrier_changes)
             log.info("carrier_down_count : %s" % iface.carrier_down_count)
 
+    @healthcheck("NetworkInterfaceCheck")
     @Scheduler.periodic(60)
     async def run_network_checks(self):
 
@@ -256,4 +257,4 @@ class NetworkHealthChecks(HealthModule):
                 report.description = f"Network Warnings"
 
 
-        await self.reporter.update_report('Network', report=report)
+        await self.reporter.update_report(self.run_network_checks.report_name, report=report)

--- a/healthagent/process.py
+++ b/healthagent/process.py
@@ -1,7 +1,7 @@
 import os
 import pwd
 import logging
-from healthagent import epilog
+from healthagent import epilog, healthcheck
 from healthagent.scheduler import Scheduler
 from healthagent.healthmodule import HealthModule
 from healthagent.reporter import Reporter, HealthStatus, HealthReport
@@ -76,6 +76,7 @@ class ProcessMonitor(HealthModule):
     async def create(self):
         Scheduler.add_task(self.monitor)
 
+    @healthcheck("ProcessStateCheck")
     @epilog
     @Scheduler.periodic(60)
     async def monitor(self):
@@ -92,7 +93,7 @@ class ProcessMonitor(HealthModule):
         """
 
         zombieproc = []
-        name = "ProcessMonitor"
+        name = self.monitor.report_name
         report = HealthReport()
         hungprocs = []
         for pid in ProcessMonitor.list_pids():

--- a/healthagent/process.py
+++ b/healthagent/process.py
@@ -76,7 +76,7 @@ class ProcessMonitor(HealthModule):
     async def create(self):
         Scheduler.add_task(self.monitor)
 
-    @healthcheck("ProcessStateCheck")
+    @healthcheck("ProcessStateCheck", description="Detect zombie and unkillable processes")
     @epilog
     @Scheduler.periodic(60)
     async def monitor(self):

--- a/project.ini
+++ b/project.ini
@@ -1,8 +1,8 @@
 [project]
 name = healthagent
 type = application
-version = 1.0.6
+version = 2.0.0
 
 [blobs]
-Files = healthagent-1.0.6.tar.gz
+Files = healthagent-2.0.0.tar.gz
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "healthagent"
-version = "1.0.6"
+version = "2.0.0"
 dependencies = ["dbus-next", "systemd-python", "pytest-asyncio"]
 
 [project.optional-dependencies]

--- a/specs/default/cluster-init/scripts/00-install.sh
+++ b/specs/default/cluster-init/scripts/00-install.sh
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 
 # Cluster-Init (v1) script to setup healthagent
-HEALTHAGENT_VERSION=1.0.6
+HEALTHAGENT_VERSION=2.0.0
 HEALTHAGENT_DIR="/opt/healthagent"
 VENV_DIR="$HEALTHAGENT_DIR/.venv"
 LOG_FILE="$HEALTHAGENT_DIR/healthagent_install.log"

--- a/tests/test_async_systemd.py
+++ b/tests/test_async_systemd.py
@@ -3,8 +3,8 @@
 These tests validate the aggregation behavior without requiring dbus or systemd.
 We subclass SystemdMonitor to stub out get_journal_entries and skip create().
 """
-from unittest.mock import AsyncMock, patch
-from healthagent.reporter import Reporter, HealthReport, HealthStatus
+from unittest.mock import AsyncMock
+from healthagent.reporter import Reporter, HealthStatus
 from healthagent.async_systemd import SystemdMonitor
 
 

--- a/tests/test_async_systemd.py
+++ b/tests/test_async_systemd.py
@@ -1,0 +1,160 @@
+"""Tests for SystemdMonitor aggregated report logic.
+
+These tests validate the aggregation behavior without requiring dbus or systemd.
+We subclass SystemdMonitor to stub out get_journal_entries and skip create().
+"""
+from unittest.mock import AsyncMock, patch
+from healthagent.reporter import Reporter, HealthReport, HealthStatus
+from healthagent.async_systemd import SystemdMonitor
+
+
+class FakeSystemdMonitor(SystemdMonitor):
+    """Testable SystemdMonitor that stubs journal access and skips dbus init."""
+
+    def __init__(self, reporter):
+        super().__init__(reporter)
+        self.journal_entries = {}
+
+    async def create(self):
+        # Skip dbus connection
+        pass
+
+    def get_journal_entries(self, service_name):
+        return self.journal_entries.get(service_name, "")
+
+
+async def test_single_service_failure():
+    reporter = Reporter()
+    reporter.update_report = AsyncMock()
+    mon = FakeSystemdMonitor(reporter)
+    mon.journal_entries["slurmd.service"] = "[2026-03-20] error: something broke\n"
+
+    await mon.set_current_state("slurmd.service", "active", "running")
+    await mon.set_current_state("slurmd.service", "failed", "failed")
+
+    report = reporter.update_report.call_args[1]["report"]
+    assert report.status == HealthStatus.ERROR
+    assert "slurmd.service" in report.description
+    assert "unhealthy" in report.description
+    assert "slurmd.service" in report.details
+    assert "something broke" in report.details
+    assert reporter.update_report.call_args[1]["name"] == "SystemdServiceCheck"
+
+
+async def test_multiple_service_failures():
+    reporter = Reporter()
+    reporter.update_report = AsyncMock()
+    mon = FakeSystemdMonitor(reporter)
+    mon.journal_entries["slurmd.service"] = "[2026-03-20] error: slurmd died\n"
+    mon.journal_entries["munge.service"] = "[2026-03-20] error: munge auth fail\n"
+
+    await mon.set_current_state("slurmd.service", "active", "running")
+    await mon.set_current_state("munge.service", "active", "running")
+    await mon.set_current_state("slurmd.service", "failed", "failed")
+    await mon.set_current_state("munge.service", "failed", "failed")
+
+    report = reporter.update_report.call_args[1]["report"]
+    assert report.status == HealthStatus.ERROR
+    assert "slurmd.service" in report.description
+    assert "munge.service" in report.description
+    # Both journal sections should appear with separators
+    assert "------ slurmd.service ------" in report.details
+    assert "------ munge.service ------" in report.details
+    assert "slurmd died" in report.details
+    assert "munge auth fail" in report.details
+
+
+async def test_service_recovery():
+    reporter = Reporter()
+    reporter.update_report = AsyncMock()
+    mon = FakeSystemdMonitor(reporter)
+    mon.journal_entries["slurmd.service"] = "[2026-03-20] error: slurmd died\n"
+
+    # Go through: inactive -> active -> failed -> active (recovery)
+    await mon.set_current_state("slurmd.service", "active", "running")
+    await mon.set_current_state("slurmd.service", "failed", "failed")
+    await mon.set_current_state("slurmd.service", "active", "running")
+
+    report = reporter.update_report.call_args[1]["report"]
+    assert report.status == HealthStatus.OK
+    assert report.description is None
+    assert report.details is None
+
+
+async def test_custom_fields_contain_per_service_status():
+    reporter = Reporter()
+    reporter.update_report = AsyncMock()
+    mon = FakeSystemdMonitor(reporter)
+    mon.journal_entries["slurmd.service"] = "[2026-03-20] error: slurmd died\n"
+
+    await mon.set_current_state("slurmd.service", "active", "running")
+    await mon.set_current_state("munge.service", "active", "running")
+    await mon.set_current_state("slurmd.service", "failed", "failed")
+
+    report = reporter.update_report.call_args[1]["report"]
+    assert report.custom_fields["slurmd.service"]["status"] == "Error"
+    assert report.custom_fields["munge.service"]["status"] == "OK"
+    assert report.custom_fields["error_count"] == 1
+
+
+async def test_no_report_on_transient_state():
+    """Transient states like activating should not trigger an aggregated report update."""
+    reporter = Reporter()
+    reporter.update_report = AsyncMock()
+    mon = FakeSystemdMonitor(reporter)
+
+    await mon.set_current_state("slurmd.service", "activating", "start")
+    # Transient state should update self.state but NOT call _update_aggregated_report
+    reporter.update_report.assert_not_called()
+    assert mon.state["slurmd.service"] == "activating"
+
+
+async def test_same_state_no_update():
+    """Duplicate state transitions should not trigger a report update."""
+    reporter = Reporter()
+    reporter.update_report = AsyncMock()
+    mon = FakeSystemdMonitor(reporter)
+
+    await mon.set_current_state("slurmd.service", "active", "running")
+    reporter.update_report.reset_mock()
+    # Same state again
+    await mon.set_current_state("slurmd.service", "active", "running")
+    reporter.update_report.assert_not_called()
+
+
+async def test_report_name_matches_healthcheck_decorator():
+    """The report name used in update_report must match the @healthcheck decorator name."""
+    reporter = Reporter()
+    reporter.update_report = AsyncMock()
+    mon = FakeSystemdMonitor(reporter)
+
+    await mon.set_current_state("slurmd.service", "active", "running")
+    await mon.set_current_state("slurmd.service", "failed", "failed")
+
+    name_arg = reporter.update_report.call_args[1]["name"]
+    assert name_arg == "SystemdServiceCheck"
+    # Verify it matches the @healthcheck decorator
+    assert name_arg == mon._update_services.report_name
+
+
+async def test_partial_recovery_still_error():
+    """If one service recovers but another is still failed, aggregate should be ERROR."""
+    reporter = Reporter()
+    reporter.update_report = AsyncMock()
+    mon = FakeSystemdMonitor(reporter)
+    mon.journal_entries["munge.service"] = "[2026-03-20] error: munge fail\n"
+
+    await mon.set_current_state("slurmd.service", "active", "running")
+    await mon.set_current_state("munge.service", "active", "running")
+    await mon.set_current_state("slurmd.service", "failed", "failed")
+    await mon.set_current_state("munge.service", "failed", "failed")
+    # slurmd recovers, munge still failed
+    await mon.set_current_state("slurmd.service", "active", "running")
+
+    report = reporter.update_report.call_args[1]["report"]
+    assert report.status == HealthStatus.ERROR
+    assert "munge.service" in report.description
+    assert "slurmd.service" not in report.description
+    assert report.custom_fields["slurmd.service"]["status"] == "OK"
+    assert report.custom_fields["munge.service"]["status"] == "Error"
+    assert report.custom_fields["error_count"] == 1

--- a/tests/test_healthmodule.py
+++ b/tests/test_healthmodule.py
@@ -216,7 +216,7 @@ def test_override_base_method_no_duplicates():
 
 class FakeEpilogWithArgs(HealthModule):
 
-    @healthcheck("MemTest")
+    @healthcheck("MemTest", args=["gpu_id"])
     @epilog
     async def memory_test(self, gpu_id: list = None):
         return {"MemTest": {"status": "OK", "gpu_id": gpu_id}}
@@ -308,9 +308,9 @@ async def test_execute_bad_kwargs_logs_error(capfd):
     reporter = Reporter()
     mod = FakeEpilogWithArgs(reporter=reporter)
 
+    # DiagTest declares no args, so kwargs are stripped and it runs normally
     result = await mod.execute("epilog", checks={"DiagTest": {"nonexistent": "value"}})
-    # DiagTest does not accept 'nonexistent', so it should be skipped with an error
-    assert "DiagTest" not in result
+    assert result["DiagTest"]["status"] == "OK"
 
 
 def test_list_checks_includes_signature():
@@ -320,7 +320,7 @@ def test_list_checks_includes_signature():
     assert "MemTest" in checks
     assert "gpu_id" in checks["MemTest"]
     assert "DiagTest" in checks
-    assert checks["DiagTest"] == "()"
+    assert checks["DiagTest"] == ""
 
 
 # --- Tests for background vs on-demand distinction ---
@@ -435,7 +435,8 @@ def test_list_all_checks_signature():
     mod = FakeFullModule(reporter=reporter)
     checks = mod.list_checks()
     for name, info in checks.items():
-        assert "signature" in info
+        assert "args" in info
+        assert "description" in info
 
 
 def test_list_checks_phase_filters_from_registry():
@@ -447,7 +448,7 @@ def test_list_checks_phase_filters_from_registry():
     assert "EpilogAndBackground" in epilog_checks
     assert "BackgroundOnly" not in epilog_checks
     assert "AsyncCallback" not in epilog_checks
-    # Phase-filtered results return {name: signature_str}
+    # Phase-filtered results return {name: args_str}
     assert isinstance(epilog_checks["EpilogOnly"], str)
 
 
@@ -510,3 +511,71 @@ def test_status_prunes_with_empty_registry():
 
     assert len(reporter.store) == 0
     assert "StaleKey" not in result
+
+
+# --- Tests for args, description, and type coercion ---
+
+class FakeDescriptionModule(HealthModule):
+    """Module to test description fallback to docstring."""
+
+    @healthcheck("WithDesc", description="Explicit description")
+    @epilog
+    async def with_desc(self):
+        return {"WithDesc": {"status": "OK"}}
+
+    @healthcheck("WithDocstring")
+    @epilog
+    async def with_docstring(self):
+        """Docstring description here"""
+        return {"WithDocstring": {"status": "OK"}}
+
+    @healthcheck("NoDesc")
+    @epilog
+    async def no_desc(self):
+        return {"NoDesc": {"status": "OK"}}
+
+
+def test_description_explicit():
+    reporter = Reporter()
+    mod = FakeDescriptionModule(reporter=reporter)
+    checks = mod.list_checks()
+    assert checks["WithDesc"]["description"] == "Explicit description"
+
+
+def test_description_fallback_to_docstring():
+    reporter = Reporter()
+    mod = FakeDescriptionModule(reporter=reporter)
+    checks = mod.list_checks()
+    assert checks["WithDocstring"]["description"] == "Docstring description here"
+
+
+def test_description_empty_when_none():
+    reporter = Reporter()
+    mod = FakeDescriptionModule(reporter=reporter)
+    checks = mod.list_checks()
+    assert checks["NoDesc"]["description"] == ""
+
+
+def test_healthcheck_args_stored():
+    reporter = Reporter()
+    mod = FakeEpilogWithArgs(reporter=reporter)
+    checks = mod.list_checks()
+    assert checks["MemTest"]["args"] == ["gpu_id"]
+    assert checks["DiagTest"]["args"] == []
+
+
+async def test_execute_coerces_string_to_list():
+    """When a comma-separated string is passed for a list param, it should be split."""
+    reporter = Reporter()
+    mod = FakeEpilogWithArgs(reporter=reporter)
+    result = await mod.execute("epilog", checks={"MemTest": {"gpu_id": "0,1,2"}})
+    assert result["MemTest"]["gpu_id"] == ["0", "1", "2"]
+
+
+async def test_execute_rejects_unknown_args():
+    """Args not declared in healthcheck_args should be stripped."""
+    reporter = Reporter()
+    mod = FakeEpilogWithArgs(reporter=reporter)
+    # MemTest allows gpu_id but not 'bad_arg'
+    result = await mod.execute("epilog", checks={"MemTest": {"gpu_id": [0], "bad_arg": "x"}})
+    assert result["MemTest"]["gpu_id"] == [0]

--- a/tests/test_healthmodule.py
+++ b/tests/test_healthmodule.py
@@ -414,7 +414,7 @@ def test_list_all_checks_categories():
     assert checks["EpilogOnly"]["category"] == ["epilog"]
     assert checks["PrologOnly"]["category"] == ["prolog"]
     assert checks["BackgroundOnly"]["category"] == ["background"]
-    assert checks["AsyncCallback"]["category"] == ["async"]
+    assert checks["AsyncCallback"]["category"] == ["background"]
     # Dual check should have both categories
     assert "epilog" in checks["EpilogAndBackground"]["category"]
     assert "background" in checks["EpilogAndBackground"]["category"]
@@ -426,8 +426,8 @@ def test_list_all_checks_interval():
     checks = mod.list_checks()
     assert checks["BackgroundOnly"]["interval"] == 120
     assert checks["EpilogAndBackground"]["interval"] == 60
-    assert "interval" not in checks["EpilogOnly"]
-    assert "interval" not in checks["AsyncCallback"]
+    assert checks["EpilogOnly"]["interval"] == -1
+    assert checks["AsyncCallback"]["interval"] == "async"
 
 
 def test_list_all_checks_signature():

--- a/tests/test_healthmodule.py
+++ b/tests/test_healthmodule.py
@@ -1,16 +1,19 @@
-from healthagent import epilog, status, prolog
+from healthagent import epilog, status, prolog, healthcheck
 from healthagent.reporter import Reporter
 from healthagent.healthmodule import HealthModule
+from healthagent.scheduler import Scheduler
 
 # Validate _get_handlers with MRO-based discovery.
 
 # Simulated module with multiple epilog handlers
 class FakeGpuModule(HealthModule):
 
+    @healthcheck("ActiveGPUHealthChecks")
     @epilog
     async def run_epilog(self):
         return {"ActiveGPUHealthChecks": {"status": "OK"}}
 
+    @healthcheck("NvlinkCheck")
     @epilog
     async def run_nvlink_epilog(self):
         return {"NvlinkCheck": {"status": "OK"}}
@@ -28,10 +31,12 @@ class FakeSystemdModule(HealthModule):
 # Module with prolog + epilog
 class FakeProcessModule(HealthModule):
 
+    @healthcheck("ZombieCheck")
     @epilog
     async def check_zombies(self):
         return {"ZombieCheck": {"status": "OK"}}
 
+    @healthcheck("Readiness")
     @prolog
     async def check_readiness(self):
         return {"Readiness": {"status": "OK"}}
@@ -40,16 +45,19 @@ class FakeProcessModule(HealthModule):
 # Module with multi-decorated methods
 class FakeMultiDecoratorModule(HealthModule):
 
+    @healthcheck("ValidateBoth")
     @prolog
     @epilog
     async def validate_both(self):
         return {"ValidateBoth": {"status": "OK"}}
 
+    @healthcheck("CheckAndReport")
     @prolog
     @status
     def check_and_report(self):
         return {"CheckAndReport": {"status": "OK"}}
 
+    @healthcheck("DoEverything")
     @prolog
     @epilog
     @status
@@ -202,3 +210,303 @@ def test_override_base_method_no_duplicates():
     assert len(handlers) == 1
     # The returned handler should be the overridden version
     assert handlers[0]() == {"custom_status": "overridden"}
+
+
+# --- Tests for @healthcheck, execute with checks filtering, list_checks, and kwargs ---
+
+class FakeEpilogWithArgs(HealthModule):
+
+    @healthcheck("MemTest")
+    @epilog
+    async def memory_test(self, gpu_id: list = None):
+        return {"MemTest": {"status": "OK", "gpu_id": gpu_id}}
+
+    @healthcheck("DiagTest")
+    @epilog
+    async def diag_test(self):
+        return {"DiagTest": {"status": "OK"}}
+
+
+def test_healthcheck_decorator_sets_report_name():
+    reporter = Reporter()
+    mod = FakeGpuModule(reporter=reporter)
+    assert mod.run_epilog.report_name == "ActiveGPUHealthChecks"
+    assert mod.run_nvlink_epilog.report_name == "NvlinkCheck"
+
+
+def test_list_checks():
+    reporter = Reporter()
+    mod = FakeGpuModule(reporter=reporter)
+    checks = mod.list_checks("epilog")
+    assert "ActiveGPUHealthChecks" in checks
+    assert "NvlinkCheck" in checks
+    assert len(checks) == 2
+
+
+def test_list_checks_empty_for_undecorated_phase():
+    reporter = Reporter()
+    mod = FakeGpuModule(reporter=reporter)
+    checks = mod.list_checks("prolog")
+    assert len(checks) == 0
+
+
+async def test_execute_with_checks_filter():
+    """When checks dict is provided, only matching handlers should run."""
+    reporter = Reporter()
+    mod = FakeGpuModule(reporter=reporter)
+
+    result = await mod.execute("epilog", checks={"ActiveGPUHealthChecks": {}})
+    assert "ActiveGPUHealthChecks" in result
+    assert "NvlinkCheck" not in result
+
+
+async def test_execute_with_checks_filter_case_insensitive():
+    """Check name matching should be case-insensitive."""
+    reporter = Reporter()
+    mod = FakeGpuModule(reporter=reporter)
+
+    result = await mod.execute("epilog", checks={"activegpuhealthchecks": {}})
+    assert "ActiveGPUHealthChecks" in result
+    assert "NvlinkCheck" not in result
+
+    result2 = await mod.execute("epilog", checks={"NVLINKCHECK": {}})
+    assert "NvlinkCheck" in result2
+    assert "ActiveGPUHealthChecks" not in result2
+
+
+async def test_execute_with_checks_none_runs_all():
+    """When checks is None, all handlers should run (backward compat)."""
+    reporter = Reporter()
+    mod = FakeGpuModule(reporter=reporter)
+
+    result = await mod.execute("epilog", checks=None)
+    assert "ActiveGPUHealthChecks" in result
+    assert "NvlinkCheck" in result
+
+
+async def test_execute_with_kwargs():
+    """Check kwargs are passed through to the handler."""
+    reporter = Reporter()
+    mod = FakeEpilogWithArgs(reporter=reporter)
+
+    result = await mod.execute("epilog", checks={"MemTest": {"gpu_id": [0, 1]}})
+    assert result["MemTest"]["gpu_id"] == [0, 1]
+    assert "DiagTest" not in result
+
+
+async def test_execute_with_kwargs_default():
+    """Handler called with no kwargs uses default args."""
+    reporter = Reporter()
+    mod = FakeEpilogWithArgs(reporter=reporter)
+
+    result = await mod.execute("epilog", checks={"MemTest": {}})
+    assert result["MemTest"]["gpu_id"] is None
+
+
+async def test_execute_bad_kwargs_logs_error(capfd):
+    """Invalid kwargs should be caught and not crash the run."""
+    reporter = Reporter()
+    mod = FakeEpilogWithArgs(reporter=reporter)
+
+    result = await mod.execute("epilog", checks={"DiagTest": {"nonexistent": "value"}})
+    # DiagTest does not accept 'nonexistent', so it should be skipped with an error
+    assert "DiagTest" not in result
+
+
+def test_list_checks_includes_signature():
+    reporter = Reporter()
+    mod = FakeEpilogWithArgs(reporter=reporter)
+    checks = mod.list_checks("epilog")
+    assert "MemTest" in checks
+    assert "gpu_id" in checks["MemTest"]
+    assert "DiagTest" in checks
+    assert checks["DiagTest"] == "()"
+
+
+# --- Tests for background vs on-demand distinction ---
+
+class FakeBackgroundOnlyModule(HealthModule):
+    """Module with only background checks — no epilog/prolog."""
+
+    @healthcheck("BackgroundMetric")
+    def some_periodic_check(self):
+        return {"BackgroundMetric": {"status": "OK"}}
+
+
+async def test_background_check_not_targetable_via_epilog():
+    """A check that only has @healthcheck (no @epilog) should not appear in epilog list_checks."""
+    reporter = Reporter()
+    mod = FakeBackgroundOnlyModule(reporter=reporter)
+    checks = mod.list_checks("epilog")
+    assert "BackgroundMetric" not in checks
+
+
+async def test_execute_epilog_skips_background_only():
+    """Targeting a background-only check via epilog should produce empty result."""
+    reporter = Reporter()
+    mod = FakeBackgroundOnlyModule(reporter=reporter)
+    result = await mod.execute("epilog", checks={"BackgroundMetric": {}})
+    assert "BackgroundMetric" not in result
+
+
+# --- Tests for list_all_checks ---
+
+class FakeFullModule(HealthModule):
+    """Module with checks in every category for list_all_checks testing."""
+
+    @healthcheck("EpilogOnly")
+    @epilog
+    async def epilog_check(self):
+        return {"EpilogOnly": {"status": "OK"}}
+
+    @healthcheck("PrologOnly")
+    @prolog
+    async def prolog_check(self):
+        return {"PrologOnly": {"status": "OK"}}
+
+    @healthcheck("BackgroundOnly")
+    @Scheduler.periodic(120)
+    async def background_check(self):
+        return {"BackgroundOnly": {"status": "OK"}}
+
+    @healthcheck("EpilogAndBackground")
+    @epilog
+    @Scheduler.periodic(60)
+    async def dual_check(self):
+        return {"EpilogAndBackground": {"status": "OK"}}
+
+    @healthcheck("AsyncCallback")
+    def callback_check(self):
+        return {"AsyncCallback": {"status": "OK"}}
+
+    @Scheduler.periodic(300)
+    async def admin_task(self):
+        """No @healthcheck — should NOT appear in list_all_checks."""
+        pass
+
+
+def test_list_all_checks_discovers_all_healthchecks():
+    reporter = Reporter()
+    mod = FakeFullModule(reporter=reporter)
+    checks = mod.list_checks()
+    assert "EpilogOnly" in checks
+    assert "PrologOnly" in checks
+    assert "BackgroundOnly" in checks
+    assert "EpilogAndBackground" in checks
+    assert "AsyncCallback" in checks
+    assert len(checks) == 5
+
+
+def test_list_all_checks_excludes_non_healthcheck():
+    """Admin tasks without @healthcheck should not appear."""
+    reporter = Reporter()
+    mod = FakeFullModule(reporter=reporter)
+    checks = mod.list_checks()
+    # admin_task has no report_name, so it must not be present
+    for info in checks.values():
+        assert "admin_task" not in str(info)
+
+
+def test_list_all_checks_categories():
+    reporter = Reporter()
+    mod = FakeFullModule(reporter=reporter)
+    checks = mod.list_checks()
+    assert checks["EpilogOnly"]["category"] == ["epilog"]
+    assert checks["PrologOnly"]["category"] == ["prolog"]
+    assert checks["BackgroundOnly"]["category"] == ["background"]
+    assert checks["AsyncCallback"]["category"] == ["async"]
+    # Dual check should have both categories
+    assert "epilog" in checks["EpilogAndBackground"]["category"]
+    assert "background" in checks["EpilogAndBackground"]["category"]
+
+
+def test_list_all_checks_interval():
+    reporter = Reporter()
+    mod = FakeFullModule(reporter=reporter)
+    checks = mod.list_checks()
+    assert checks["BackgroundOnly"]["interval"] == 120
+    assert checks["EpilogAndBackground"]["interval"] == 60
+    assert "interval" not in checks["EpilogOnly"]
+    assert "interval" not in checks["AsyncCallback"]
+
+
+def test_list_all_checks_signature():
+    reporter = Reporter()
+    mod = FakeFullModule(reporter=reporter)
+    checks = mod.list_checks()
+    for name, info in checks.items():
+        assert "signature" in info
+
+
+def test_list_checks_phase_filters_from_registry():
+    """list_checks with a phase should only return checks in that category."""
+    reporter = Reporter()
+    mod = FakeFullModule(reporter=reporter)
+    epilog_checks = mod.list_checks("epilog")
+    assert "EpilogOnly" in epilog_checks
+    assert "EpilogAndBackground" in epilog_checks
+    assert "BackgroundOnly" not in epilog_checks
+    assert "AsyncCallback" not in epilog_checks
+    # Phase-filtered results return {name: signature_str}
+    assert isinstance(epilog_checks["EpilogOnly"], str)
+
+
+def test_list_checks_cached():
+    """Calling list_checks multiple times should return the same cached registry."""
+    reporter = Reporter()
+    mod = FakeFullModule(reporter=reporter)
+    first = mod.list_checks()
+    second = mod.list_checks()
+    assert first is second
+
+
+# --- Tests for stale report pruning ---
+
+from healthagent.reporter import HealthReport
+
+def test_status_prunes_stale_reporter_keys():
+    """Reporter keys that don't match any registered healthcheck should be removed by status()."""
+    reporter = Reporter()
+    # Simulate stale keys restored from a pickle (old check names)
+    reporter.store["OldRenamedCheck"] = HealthReport()
+    reporter.store["AnotherObsoleteCheck"] = HealthReport()
+    # Add a valid key that matches a real healthcheck
+    reporter.store["ActiveGPUHealthChecks"] = HealthReport()
+
+    mod = FakeGpuModule(reporter=reporter)
+    result = mod.status()
+
+    # Stale keys should be gone
+    assert "OldRenamedCheck" not in reporter.store
+    assert "AnotherObsoleteCheck" not in reporter.store
+    # Valid key should remain
+    assert "ActiveGPUHealthChecks" in reporter.store
+    # Summarized result should only contain the valid key
+    assert "OldRenamedCheck" not in result
+    assert "ActiveGPUHealthChecks" in result
+
+
+def test_status_no_pruning_when_all_keys_valid():
+    """When all reporter keys match registered checks, nothing should be pruned."""
+    reporter = Reporter()
+    reporter.store["ActiveGPUHealthChecks"] = HealthReport()
+    reporter.store["NvlinkCheck"] = HealthReport()
+
+    mod = FakeGpuModule(reporter=reporter)
+    result = mod.status()
+
+    assert len(reporter.store) == 2
+    assert "ActiveGPUHealthChecks" in result
+    assert "NvlinkCheck" in result
+
+
+def test_status_prunes_with_empty_registry():
+    """Module with no healthchecks should prune all reporter keys."""
+    reporter = Reporter()
+    reporter.store["StaleKey"] = HealthReport()
+
+    mod = FakeSystemdModule(reporter=reporter)
+    result = mod.status()
+
+    assert len(reporter.store) == 0
+    assert "StaleKey" not in result


### PR DESCRIPTION
- Adds a new healthcheck decorator that specifies the name of the check as it appears in the final output.
- Also allows to send arguments to specific epilog/prolog checks via the CLI.
- Add list checks feature to list all healthchecks. Adds a -l cli to health client that shows all currently running checks as well as their intervals.
- Renames checks to better reflect their purpose
- Refactor systemd checks to take advantage of healthcheck decorator. Allows systemd checks to show up in CLI list views.