### PR TITLE
Add auxiliary data for storing internal fields.

### DIFF
--- a/healthagent/reporter.py
+++ b/healthagent/reporter.py
@@ -1,9 +1,9 @@
 import copy
 from enum import Enum
-from dataclasses import dataclass, asdict, is_dataclass, field
+from dataclasses import dataclass, asdict, is_dataclass, field, InitVar
 from datetime import datetime, timedelta, timezone
 from time import time
-from typing import Any,Dict
+from typing import Any, Dict
 import logging
 import os
 from healthagent.scheduler import Scheduler
@@ -80,6 +80,11 @@ class HealthReport:
     last_update: datetime = field(init=False)
     "custom module specific data"
     custom_fields: Dict[str, Any] = None
+    # InitVar: aux_data is accepted by __init__ but excluded from dataclass fields,
+    # so asdict() / equality / view() never see it. It is stored as a plain instance
+    # attribute in __post_init__. Note: aux_data will not survive an asdict() round-trip;
+    # use deepcopy(report) to preserve it.
+    aux_data: InitVar[Dict[str, Any]] = None
 
     def __eq__(self, other):
         if not isinstance(other, HealthReport):
@@ -91,9 +96,10 @@ class HealthReport:
         d2.pop('last_update', None)
         return d1 == d2
 
-    def __post_init__(self):
+    def __post_init__(self, aux_data: Dict[str, Any] | None):
         if self.custom_fields is None:
             self.custom_fields = {}
+        self.aux_data = aux_data
         self.last_update = datetime.now(tz=timezone.utc)
 
     def __getattr__(self, item):
@@ -113,6 +119,11 @@ class HealthReport:
             self.status = new_status
 
     def view(self) -> Dict[str, Any]:
+        """
+        View method shows the healthreport in its final form.
+        aux_data is an InitVar and is excluded from asdict() automatically.
+        Custom fields are module specific and are merged to top_level.
+        """
         # Convert the dataclass to a dictionary
         base_dict = make_json_safe(asdict(self))
         # Merge custom_fields into the top-level dictionary

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -139,6 +139,62 @@ def test_make_json_safe_with_custom_class_enum_datetime_set():
         assert False, f"make_json_safe failed on custom class with enum, datetime, set: {e}"
 
 
+def test_aux_data_excluded_from_view():
+    """aux_data should never appear in view() output."""
+    report = HealthReport(
+        status=HealthStatus.ERROR,
+        description="GPU failure",
+        aux_data={"raw_stdout": "some debug output", "exit_code": 1},
+    )
+    view = report.view()
+    assert "aux_data" not in view
+    assert "raw_stdout" not in view
+    assert "exit_code" not in view
+    # Normal fields should still be present
+    assert view["status"] == "Error"
+    assert view["description"] == "GPU failure"
+
+
+def test_aux_data_excluded_from_equality():
+    """Two reports differing only in aux_data should be equal."""
+    r1 = HealthReport(status=HealthStatus.WARNING, description="test")
+    r2 = HealthReport(
+        status=HealthStatus.WARNING,
+        description="test",
+        aux_data={"debug": "info"},
+    )
+    assert r1 == r2
+
+
+def test_aux_data_not_in_summarize():
+    """Summarize output must not contain aux_data."""
+    reporter = Reporter()
+    reporter.publish_cc = False
+    name = "gpu_test"
+    report = HealthReport(
+        status=HealthStatus.ERROR,
+        description="fail",
+        aux_data={"internal_log": "verbose data"},
+    )
+    reporter.store[name] = report
+    summary = reporter.summarize()
+    assert "aux_data" not in summary[name]
+    assert "internal_log" not in summary[name]
+
+
+def test_aux_data_accessible_on_report():
+    """Modules should be able to read/write aux_data directly."""
+    report = HealthReport(aux_data={"key": "val"})
+    assert report.aux_data == {"key": "val"}
+    report.aux_data["key2"] = 42
+    assert report.aux_data["key2"] == 42
+
+
+def test_aux_data_defaults_to_none():
+    report = HealthReport()
+    assert report.aux_data is None
+
+
 async def test_reporter():
 
     my_reporter = Reporter()


### PR DESCRIPTION
Aux data is purely for modules to store internal state.