### PR TITLE
GPU: Initial refactoring commit

### DIFF
--- a/healthagent/bindings.py
+++ b/healthagent/bindings.py
@@ -75,37 +75,27 @@ def _resolve_error_codes_with_notes(*pairs):
             codes[code] = f"Healthagent Note: {note}"
     return codes
 
-# Single source of truth for DCGM field definitions.
+# System/reference fields — needed by non-watch code (XID handling, gpu_count_check,
+# display config, detail lookups). Not user-configurable thresholds.
 # (alias, dcgm_fields attribute name)
-# Some fields are event driven (by NVML) and others are polled.
-_FIELD_DEFS = [
-    # Dev count
-    ("DEVCNT", "DCGM_FI_DEV_CNT"),
-    # Thermal & Power
-    ("GPUTEMP",          "DCGM_FI_DEV_GPU_TEMP"),
+_SYSTEM_FIELDS = [
+    # Dev count — used by gpu_count_check
+    ("DEVCNT",           "DCGM_FI_DEV_CNT"),
+    # Reference temps — used by __display_gpu_config / telemetry
     ("GPUTEMP_SLOWDOWN", "DCGM_FI_DEV_SLOWDOWN_TEMP"),
     ("GPUTEMP_SHUTDOWN",  "DCGM_FI_DEV_SHUTDOWN_TEMP"),
-    ("GPUPOWER",          "DCGM_FI_DEV_POWER_USAGE"),
-    # Clocks
-    ("CLOCK_REASON",      "DCGM_FI_DEV_CLOCK_THROTTLE_REASONS"),
-    # Fabric
-    ("FABRIC_STATUS",     "DCGM_FI_DEV_FABRIC_MANAGER_STATUS"),
+    # Fabric error code — detail field read on fabric status trigger
     ("FABRIC_ERROR",      "DCGM_FI_DEV_FABRIC_MANAGER_ERROR_CODE"),
-    # Driver
-    ("PERSISTENCE_MODE",  "DCGM_FI_DEV_PERSISTENCE_MODE"),
-    # Errors
+    # XID — event-driven, handled separately via XID_WARNING/XID_IGNORE
     ("XID_ERRORS",        "DCGM_FI_DEV_XID_ERRORS"),
-    ("DBE_ERRORS",        "DCGM_FI_DEV_ECC_DBE_VOL_TOTAL"),
-    ("RECOVERY_ACTION",   "DCGM_FI_DEV_GET_GPU_RECOVERY_ACTION"),
-    ("ROW_REMAP_FAIL",    "DCGM_FI_DEV_ROW_REMAP_FAILURE"),
 ]
 
 class _Fields:
-    """Namespace for DCGM field IDs, populated from _FIELD_DEFS.
+    """Namespace for DCGM field IDs, populated from _SYSTEM_FIELDS.
     Missing fields on older DCGM versions are set to None."""
     avail_field_ids = []
 
-for _alias, _dcgm_name in _FIELD_DEFS:
+for _alias, _dcgm_name in _SYSTEM_FIELDS:
     _field_id = getattr(dcgm_fields, _dcgm_name, None)
     setattr(_Fields, _alias, _field_id)
     if _field_id is not None:
@@ -123,7 +113,6 @@ for _alias, _dcgm_name in _FIELD_DEFS:
 _FIELD_WATCHES = [
     {"field": "DCGM_FI_DEV_GPU_TEMP",               "eval": "gt",       "warning": 83, "error": 90, "category": "Thermal",        "message": "GPU {gpu} temperature {value}\u00b0C exceeds {threshold}\u00b0C"},
     {"field": "DCGM_FI_DEV_CLOCKS_EVENT_REASONS",   "eval": "bitmask",                 "error": 0xE8, "category": "Clocks",       "message": "GPU {gpu} clock throttle reasons active: {value:#x} (mask: {threshold:#x})"},
-    {"field": "DCGM_FI_DEV_FABRIC_MANAGER_STATUS",   "eval": "in",                     "error": [4, 1], "category": "FabricManager", "message": "GPU {gpu} Fabric Manager unhealthy (status: {value})"},
     {"field": "DCGM_FI_DEV_PERSISTENCE_MODE",        "eval": "ne",                     "error": 1,    "category": "System",        "message": "GPU {gpu} persistence mode not set. Restart nvidia-persistenced or reboot."},
     {"field": "DCGM_FI_DEV_GET_GPU_RECOVERY_ACTION", "eval": "in",  "warning": [2],    "error": [3, 4], "category": "System",      "message": "GPU {gpu} recovery action requested (action: {value})"},
     {"field": "DCGM_FI_DEV_ROW_REMAP_FAILURE",       "eval": "ne",                     "error": 0,    "category": "Memory",        "message": "GPU {gpu} row remap failure detected"},
@@ -157,6 +146,19 @@ class Wrap:
     fields = _Fields
     default_field_watches = resolve_field_watches(_FIELD_WATCHES)
 
+    ENTITY_GROUP_NAMES = {
+        dcgm_fields.DCGM_FE_NONE: "None",
+        dcgm_fields.DCGM_FE_GPU: "GPU",
+        dcgm_fields.DCGM_FE_VGPU: "vGPU",
+        dcgm_fields.DCGM_FE_SWITCH: "Switch",
+        dcgm_fields.DCGM_FE_GPU_I: "GPU_I",
+        dcgm_fields.DCGM_FE_GPU_CI: "GPU_CI",
+        dcgm_fields.DCGM_FE_LINK: "Link",
+        dcgm_fields.DCGM_FE_CPU: "CPU",
+        dcgm_fields.DCGM_FE_CPU_CORE: "CPU_Core",
+        dcgm_fields.DCGM_FE_CONNECTX: "ConnectX",
+    }
+
     @classmethod
     def get_fields(cls):
         return list(_Fields.avail_field_ids)
@@ -165,9 +167,9 @@ class Wrap:
         "DCGM_FR_NVLINK_ERROR_CRITICAL",
         "DCGM_FR_NVLINK_DOWN",
         "DCGM_FR_NVSWITCH_FATAL_ERROR",
-        "DCGM_FR_ROW_REMAP_FAILURE",
         "DCGM_FR_FAULTY_MEMORY",
         "DCGM_FR_FIELD_VIOLATION",
+        "DCGM_FR_FABRIC_PROBE_STATE"
     )
 
     HEALTH_WARNINGS = _resolve_error_codes(
@@ -222,7 +224,7 @@ class Wrap:
         "DCGM_FR_XID_ERROR"
     )
 
-    DIAG_SUPPRESSED_NOTE = "Healthagent Note: Low confidence. Suppressed to avoid false positives."
+    DIAG_SUPPRESSED_NOTE = "Healthagent Note: Low confidence. Suppressed to avoid false positives or duplicated errors that do not represent diagnostic test failures."
 
     @classmethod
     def count_os_gpu_devices(cls) -> int:
@@ -306,7 +308,7 @@ class Wrap:
         return gpu_count
 
     @classmethod
-    def get_throttle_reasons(cls, clock_reason):
+    def get_throttle_reasons(cls, clock_reason, field_values=None):
         reasons = []
 
         # This is an indicator of:

--- a/healthagent/bindings.py
+++ b/healthagent/bindings.py
@@ -111,6 +111,38 @@ for _alias, _dcgm_name in _FIELD_DEFS:
     if _field_id is not None:
         _Fields.avail_field_ids.append(_field_id)
 
+# Default field watches — built-in thresholds for health evaluation.
+# Same shape as future YAML config. Each entry is one watch:
+#   field:    DCGM field constant name (string)
+#   eval:     evaluation type (gt, lt, ge, le, eq, ne, in, bitmask, delta_gt)
+#   warning:  threshold for warning severity (number or list for 'in'; omit if not needed)
+#   error:    threshold for error severity (number or list for 'in'; omit if not needed)
+#   category: reporting category string
+#   message:  template with {gpu}, {value}, {threshold} placeholders
+#   window:   (optional) rate normalization window in seconds for delta_gt (default: 60, max: 300)
+_FIELD_WATCHES = [
+    {"field": "DCGM_FI_DEV_GPU_TEMP",               "eval": "gt",       "warning": 83, "error": 90, "category": "Thermal",        "message": "GPU {gpu} temperature {value}\u00b0C exceeds {threshold}\u00b0C"},
+    {"field": "DCGM_FI_DEV_CLOCKS_EVENT_REASONS",   "eval": "bitmask",                 "error": 0xE8, "category": "Clocks",       "message": "GPU {gpu} clock throttle reasons active: {value:#x} (mask: {threshold:#x})"},
+    {"field": "DCGM_FI_DEV_FABRIC_MANAGER_STATUS",   "eval": "in",                     "error": [4, 1], "category": "FabricManager", "message": "GPU {gpu} Fabric Manager unhealthy (status: {value})"},
+    {"field": "DCGM_FI_DEV_PERSISTENCE_MODE",        "eval": "ne",                     "error": 1,    "category": "System",        "message": "GPU {gpu} persistence mode not set. Restart nvidia-persistenced or reboot."},
+    {"field": "DCGM_FI_DEV_GET_GPU_RECOVERY_ACTION", "eval": "in",  "warning": [2],    "error": [3, 4], "category": "System",      "message": "GPU {gpu} recovery action requested (action: {value})"},
+    {"field": "DCGM_FI_DEV_ROW_REMAP_FAILURE",       "eval": "ne",                     "error": 0,    "category": "Memory",        "message": "GPU {gpu} row remap failure detected"},
+    {"field": "DCGM_FI_DEV_ECC_DBE_VOL_TOTAL",       "eval": "gt",                     "error": 0,    "category": "Memory",        "message": "GPU {gpu} volatile DBE errors detected: {value}"},
+    {"field": "DCGM_FI_DEV_RETIRED_SBE",             "eval": "gt",       "warning": 50, "error": 63, "category": "Memory",        "message": "GPU {gpu} retired SBE pages: {value} (threshold: {threshold})"},
+    {"field": "DCGM_FI_DEV_ECC_SBE_AGG_TOTAL",       "eval": "delta_gt", "warning": 100,              "category": "Memory",        "message": "GPU {gpu} SBE rate {value:.0f}/min exceeds {threshold}/min"},
+    {"field": "DCGM_FI_DEV_PCIE_REPLAY_COUNTER",     "eval": "delta_gt", "warning": 50, "error": 200, "category": "PCIe",         "message": "GPU {gpu} PCIe replay rate {value:.0f}/min exceeds {threshold}/min"},
+]
+
+def resolve_field_watches(watches):
+    """Resolve field name strings to DCGM field IDs.
+    Skips watches with unknown fields (forward-compatibility)."""
+    resolved = []
+    for watch in watches:
+        field_id = getattr(dcgm_fields, watch["field"], None)
+        if field_id is not None:
+            resolved.append({**watch, "field_id": field_id})
+    return resolved
+
 class Wrap:
 
     class DcgmConnectionFail(Exception):
@@ -123,6 +155,7 @@ class Wrap:
         pass
 
     fields = _Fields
+    default_field_watches = resolve_field_watches(_FIELD_WATCHES)
 
     @classmethod
     def get_fields(cls):

--- a/healthagent/bindings.py
+++ b/healthagent/bindings.py
@@ -55,6 +55,61 @@ def create_c_callback(func: callable, loop: asyncio.BaseEventLoop):
         loop.call_soon_threadsafe(asyncio.create_task, func(callbackResp))
     return c_callback
 
+def _resolve_error_codes(*names):
+    """Safely resolve DCGM_FR_* names to their integer codes, skipping any
+    that don't exist in the installed dcgm_errors module."""
+    codes = set()
+    for name in names:
+        code = getattr(dcgm_errors, name, None)
+        if code is not None:
+            codes.add(code)
+    return codes
+
+def _resolve_error_codes_with_notes(*pairs):
+    """Resolve (DCGM_FR_name, note) pairs to {int_code: note} dict,
+    skipping any that don't exist in the installed dcgm_errors module."""
+    codes = {}
+    for name, note in pairs:
+        code = getattr(dcgm_errors, name, None)
+        if code is not None:
+            codes[code] = f"Healthagent Note: {note}"
+    return codes
+
+# Single source of truth for DCGM field definitions.
+# (alias, dcgm_fields attribute name)
+# Some fields are event driven (by NVML) and others are polled.
+_FIELD_DEFS = [
+    # Dev count
+    ("DEVCNT", "DCGM_FI_DEV_CNT"),
+    # Thermal & Power
+    ("GPUTEMP",          "DCGM_FI_DEV_GPU_TEMP"),
+    ("GPUTEMP_SLOWDOWN", "DCGM_FI_DEV_SLOWDOWN_TEMP"),
+    ("GPUTEMP_SHUTDOWN",  "DCGM_FI_DEV_SHUTDOWN_TEMP"),
+    ("GPUPOWER",          "DCGM_FI_DEV_POWER_USAGE"),
+    # Clocks
+    ("CLOCK_REASON",      "DCGM_FI_DEV_CLOCK_THROTTLE_REASONS"),
+    # Fabric
+    ("FABRIC_STATUS",     "DCGM_FI_DEV_FABRIC_MANAGER_STATUS"),
+    ("FABRIC_ERROR",      "DCGM_FI_DEV_FABRIC_MANAGER_ERROR_CODE"),
+    # Driver
+    ("PERSISTENCE_MODE",  "DCGM_FI_DEV_PERSISTENCE_MODE"),
+    # Errors
+    ("XID_ERRORS",        "DCGM_FI_DEV_XID_ERRORS"),
+    ("DBE_ERRORS",        "DCGM_FI_DEV_ECC_DBE_VOL_TOTAL"),
+    ("RECOVERY_ACTION",   "DCGM_FI_DEV_GET_GPU_RECOVERY_ACTION"),
+    ("ROW_REMAP_FAIL",    "DCGM_FI_DEV_ROW_REMAP_FAILURE"),
+]
+
+class _Fields:
+    """Namespace for DCGM field IDs, populated from _FIELD_DEFS.
+    Missing fields on older DCGM versions are set to None."""
+    avail_field_ids = []
+
+for _alias, _dcgm_name in _FIELD_DEFS:
+    _field_id = getattr(dcgm_fields, _dcgm_name, None)
+    setattr(_Fields, _alias, _field_id)
+    if _field_id is not None:
+        _Fields.avail_field_ids.append(_field_id)
 
 class Wrap:
 
@@ -67,16 +122,74 @@ class Wrap:
     class DcgmGpuNotFound(Exception):
         pass
 
-    class fields():
+    fields = _Fields
 
-        GPUTEMP = dcgm_fields.DCGM_FI_DEV_GPU_TEMP
-        GPUTEMP_SLOWDOWN = dcgm_fields.DCGM_FI_DEV_SLOWDOWN_TEMP
-        GPUTEMP_SHUTDOWN = dcgm_fields.DCGM_FI_DEV_SHUTDOWN_TEMP
-        CLOCK_REASON = dcgm_fields.DCGM_FI_DEV_CLOCK_THROTTLE_REASONS
-        FABRIC_STATUS = dcgm_fields.DCGM_FI_DEV_FABRIC_MANAGER_STATUS
-        FABRIC_ERROR = dcgm_fields.DCGM_FI_DEV_FABRIC_MANAGER_ERROR_CODE
-        GPUPOWER = dcgm_fields.DCGM_FI_DEV_POWER_USAGE
-        PERSISTENCE_MODE = dcgm_fields.DCGM_FI_DEV_PERSISTENCE_MODE
+    @classmethod
+    def get_fields(cls):
+        return list(_Fields.avail_field_ids)
+
+    HEALTH_ERRORS = _resolve_error_codes(
+        "DCGM_FR_NVLINK_ERROR_CRITICAL",
+        "DCGM_FR_NVLINK_DOWN",
+        "DCGM_FR_NVSWITCH_FATAL_ERROR",
+        "DCGM_FR_ROW_REMAP_FAILURE",
+        "DCGM_FR_FAULTY_MEMORY",
+        "DCGM_FR_FIELD_VIOLATION",
+    )
+
+    HEALTH_WARNINGS = _resolve_error_codes(
+        "DCGM_FR_PCI_REPLAY_RATE",
+        "DCGM_FR_CORRUPT_INFOROM",
+        "DCGM_FR_NVSWITCH_NON_FATAL_ERROR",
+        "DCGM_FR_NVLINK_SYMBOL_BER_THRESHOLD",
+        "DCGM_FR_NVLINK_EFFECTIVE_BER_THRESHOLD",
+    )
+
+    DIAG_ERRORS = _resolve_error_codes(
+        "DCGM_FR_CUDA_DBE",
+        "DCGM_FR_MEMORY_MISMATCH",
+        "DCGM_FR_L1TAG_MISCOMPARE",
+        "DCGM_FR_BROKEN_P2P_MEMORY_DEVICE",
+        "DCGM_FR_BROKEN_P2P_WRITER_DEVICE",
+        "DCGM_FR_BROKEN_P2P_NVLINK_WRITER_DEVICE",
+        "DCGM_FR_BROKEN_P2P_NVLINK_MEMORY_DEVICE",
+        "DCGM_FR_BROKEN_P2P_PCIE_MEMORY_DEVICE",
+        "DCGM_FR_BROKEN_P2P_PCIE_WRITER_DEVICE",
+        "DCGM_FR_CORRUPT_INFOROM",
+        "DCGM_FR_CANNOT_OPEN_LIB",
+        "DCGM_FR_DENYLISTED_DRIVER",
+        "DCGM_FR_BAD_CUDA_ENV",
+        "DCGM_FR_FAULTY_MEMORY",
+        "DCGM_FR_GPU_EXPECTED_NVLINKS_UP",
+        "DCGM_FR_NVSWITCH_EXPECTED_NVLINKS_UP",
+        "DCGM_FR_FABRIC_MANAGER_TRAINING_ERROR",
+        "DCGM_FR_UNCORRECTABLE_ROW_REMAP",
+        "DCGM_FR_PENDING_ROW_REMAP",
+        "DCGM_FR_PENDING_PAGE_RETIREMENTS",
+        "DCGM_FR_DBE_PENDING_PAGE_RETIREMENTS"
+    )
+
+    DIAG_WARNINGS = _resolve_error_codes_with_notes(
+        ("DCGM_FR_FIELD_QUERY", "Transient DCGM field read failure, not indicative of fault"),
+        ("DCGM_FR_RETIRED_PAGES_LIMIT", "Disputed or undefined Threshold. Use field watches to set custom thresholds"),
+        ("DCGM_FR_PCIE_H_REPLAY_VIOLATION", "Disputed or undefined Threshold. Use field watches to set custom thresholds"),
+        ("DCGM_FR_FIELD_THRESHOLD", "Disputed or undefined Threshold. Use field watches to set custom thresholds"),
+        ("DCGM_FR_FIELD_THRESHOLD_TS", "Disputed or undefined Threshold. Use field watches to set custom thresholds"),
+        ("DCGM_FR_NVLINK_EFFECTIVE_BER_THRESHOLD", "Disputed or undefined Threshold. Use field watches to set custom thresholds"),
+        ("DCGM_FR_NVLINK_SYMBOL_BER_THRESHOLD", "Disputed or undefined Threshold. Use field watches to set custom thresholds"),
+        ("DCGM_FR_CONCURRENT_GPUS", "Not indicative of failure"),
+        ("DCGM_FR_DCGM_API", "Second order effect - Not root cause"),
+        ("DCGM_FR_INTERNAL", "Disputed or undefined Threshold. Use field watches to set custom thresholds"),
+        ("DCGM_FR_HIGH_LATENCY", "Disputed or undefined Threshold. Use field watches to set custom thresholds"),
+        ("DCGM_FR_LOW_BANDWIDTH", "Disputed or undefined Threshold. Use field watches to set custom thresholds"),
+        ("DCGM_FR_SRAM_THRESHOLD", "Disputed or undefined Threshold. Use field watches to set custom thresholds"),
+    )
+
+    DIAG_IGNORE = _resolve_error_codes(
+        "DCGM_FR_XID_ERROR"
+    )
+
+    DIAG_SUPPRESSED_NOTE = "Healthagent Note: Low confidence. Suppressed to avoid false positives."
 
     @classmethod
     def count_os_gpu_devices(cls) -> int:
@@ -195,19 +308,6 @@ class Wrap:
         return reasons
 
     @classmethod
-    def get_fields(cls):
-        return [
-            Wrap.fields.CLOCK_REASON,
-            Wrap.fields.FABRIC_ERROR,
-            Wrap.fields.FABRIC_STATUS,
-            Wrap.fields.GPUPOWER,
-            Wrap.fields.GPUTEMP,
-            Wrap.fields.GPUTEMP_SHUTDOWN,
-            Wrap.fields.GPUTEMP_SLOWDOWN,
-            Wrap.fields.PERSISTENCE_MODE
-        ]
-
-    @classmethod
     def convert_system_enum_to_system_name(cls, system):
         if system == dcgm_structs.DCGM_HEALTH_WATCH_PCIE:
             return "PCIe"
@@ -302,7 +402,6 @@ class Wrap:
         else:
             raise ValueError("Unknown condition")
 
-    # Returns true if the error here should be ignored
     @classmethod
     def should_ignore_error(cls, diagException):
         if diagException.info:
@@ -362,7 +461,7 @@ class Wrap:
             del(handle)
 
     @classmethod
-    def set_policy(cls, mpe):
+    def set_policy(cls):
         """
         Setup policy violations and thresholds.
         Add required fields for tracking.
@@ -371,45 +470,13 @@ class Wrap:
         policy = dcgm_structs.c_dcgmPolicy_v1()
         policy.version = dcgm_structs.dcgmPolicy_version1
 
-        # Double Bit Errors
-        policy.condition = dcgm_structs.DCGM_POLICY_COND_DBE
-        policy.parms[dcgm_structs.DCGM_POLICY_COND_IDX_DBE].tag = 0
-        policy.parms[dcgm_structs.DCGM_POLICY_COND_IDX_DBE].val.boolean = True
-
-        # PCIe replay errors
-        policy.condition |= dcgm_structs.DCGM_POLICY_COND_PCI
-        policy.parms[dcgm_structs.DCGM_POLICY_COND_IDX_PCI].tag = 0
-        policy.parms[dcgm_structs.DCGM_POLICY_COND_IDX_PCI].val.llval = 1
-
-        # Nvlink Errors
-        policy.condition |= dcgm_structs.DCGM_POLICY_COND_NVLINK
-        policy.parms[dcgm_structs.DCGM_POLICY_COND_IDX_NVLINK].tag = 0
-        policy.parms[dcgm_structs.DCGM_POLICY_COND_IDX_NVLINK].val.boolean = True
-
         # XID errors
         policy.condition |= dcgm_structs.DCGM_POLICY_COND_XID
-        policy.parms[dcgm_structs.DCGM_POLICY_COND_IDX_XID].tag = 0
-        policy.parms[dcgm_structs.DCGM_POLICY_COND_IDX_XID].val.boolean = True
+        policy.parms[dcgm_structs.DCGM_POLICY_COND_IDX_XID].tag = 1
+        policy.parms[dcgm_structs.DCGM_POLICY_COND_IDX_XID].val.llval = 1
 
-
-        # # Thermal errors
-        # policy.condition |= dcgm_structs.DCGM_POLICY_COND_THERMAL
-        # policy.parms[dcgm_structs.DCGM_POLICY_COND_IDX_THERMAL].tag = 1
-        # policy.parms[dcgm_structs.DCGM_POLICY_COND_IDX_THERMAL].val.llval = temperature
-
-        # Max pages retired errors
-        policy.condition |= dcgm_structs.DCGM_POLICY_COND_MAX_PAGES_RETIRED
-        policy.parms[dcgm_structs.DCGM_POLICY_COND_IDX_MAX_PAGES_RETIRED].tag = 1
-        policy.parms[dcgm_structs.DCGM_POLICY_COND_IDX_MAX_PAGES_RETIRED].val.llval = mpe
-
-
-        # # Power draw HW errors
-        # policy.condition |= dcgm_structs.DCGM_POLICY_COND_POWER
-        # policy.parms[dcgm_structs.DCGM_POLICY_COND_IDX_POWER].tag = 1
-        # policy.parms[dcgm_structs.DCGM_POLICY_COND_IDX_POWER].val.llval = power
 
         return policy
-
     @classmethod
     def get_health_mask(cls):
         exclude_mask = dcgm_structs.DCGM_HEALTH_WATCH_THERMAL | dcgm_structs.DCGM_HEALTH_WATCH_POWER

--- a/healthagent/bindings.py
+++ b/healthagent/bindings.py
@@ -101,35 +101,34 @@ for _alias, _dcgm_name in _SYSTEM_FIELDS:
     if _field_id is not None:
         _Fields.avail_field_ids.append(_field_id)
 
-# Default field watches — built-in thresholds for health evaluation.
-# Same shape as future YAML config. Each entry is one watch:
-#   field:    DCGM field constant name (string)
-#   eval:     evaluation type (gt, lt, ge, le, eq, ne, in, bitmask, delta_gt)
-#   warning:  threshold for warning severity (number or list for 'in'; omit if not needed)
-#   error:    threshold for error severity (number or list for 'in'; omit if not needed)
-#   category: reporting category string
-#   message:  template with {gpu}, {value}, {threshold} placeholders
-#   window:   (optional) rate normalization window in seconds for delta_gt (default: 60, max: 300)
-_FIELD_WATCHES = [
-    {"field": "DCGM_FI_DEV_GPU_TEMP",               "eval": "gt",       "warning": 83, "error": 90, "category": "Thermal",        "message": "GPU {gpu} temperature {value}\u00b0C exceeds {threshold}\u00b0C"},
-    {"field": "DCGM_FI_DEV_CLOCKS_EVENT_REASONS",   "eval": "bitmask",                 "error": 0xE8, "category": "Clocks",       "message": "GPU {gpu} clock throttle reasons active: {value:#x} (mask: {threshold:#x})"},
-    {"field": "DCGM_FI_DEV_PERSISTENCE_MODE",        "eval": "ne",                     "error": 1,    "category": "System",        "message": "GPU {gpu} persistence mode not set. Restart nvidia-persistenced or reboot."},
-    {"field": "DCGM_FI_DEV_GET_GPU_RECOVERY_ACTION", "eval": "in",  "warning": [2],    "error": [3, 4], "category": "System",      "message": "GPU {gpu} recovery action requested (action: {value})"},
-    {"field": "DCGM_FI_DEV_ROW_REMAP_FAILURE",       "eval": "ne",                     "error": 0,    "category": "Memory",        "message": "GPU {gpu} row remap failure detected"},
-    {"field": "DCGM_FI_DEV_ECC_DBE_VOL_TOTAL",       "eval": "gt",                     "error": 0,    "category": "Memory",        "message": "GPU {gpu} volatile DBE errors detected: {value}"},
-    {"field": "DCGM_FI_DEV_RETIRED_SBE",             "eval": "gt",       "warning": 50, "error": 63, "category": "Memory",        "message": "GPU {gpu} retired SBE pages: {value} (threshold: {threshold})"},
-    {"field": "DCGM_FI_DEV_ECC_SBE_AGG_TOTAL",       "eval": "delta_gt", "warning": 100,              "category": "Memory",        "message": "GPU {gpu} SBE rate {value:.0f}/min exceeds {threshold}/min"},
-    {"field": "DCGM_FI_DEV_PCIE_REPLAY_COUNTER",     "eval": "delta_gt", "warning": 50, "error": 200, "category": "PCIe",         "message": "GPU {gpu} PCIe replay rate {value:.0f}/min exceeds {threshold}/min"},
-]
+def resolve_config_field_watches(config_watches: dict) -> list:
+    """Convert config field_watches dict into resolved runtime list.
 
-def resolve_field_watches(watches):
-    """Resolve field name strings to DCGM field IDs.
-    Skips watches with unknown fields (forward-compatibility)."""
+    Config format (from defaults.yaml / user overrides)::
+
+        {"DCGM_FI_DEV_GPU_TEMP": ThresholdCheck(eval="gt", warning=83, msg="...", category="Thermal"), ...}
+
+    Runtime format (used by track_fieldsv2)::
+
+        [{"field": "DCGM_FI_DEV_GPU_TEMP", "field_id": 203, "eval": "gt",
+          "warning": 83, "message": "...", "category": "Thermal"}, ...]
+
+    Skips fields not found in dcgm_fields (forward-compatibility).
+    """
     resolved = []
-    for watch in watches:
-        field_id = getattr(dcgm_fields, watch["field"], None)
-        if field_id is not None:
-            resolved.append({**watch, "field_id": field_id})
+    for field_name, watch_cfg in config_watches.items():
+        field_id = getattr(dcgm_fields, field_name, None)
+        if field_id is None:
+            continue
+        watch_dict = watch_cfg.model_dump(exclude_none=True)
+        entry = {"field": field_name, "field_id": field_id}
+        for key, val in watch_dict.items():
+            # Config uses 'msg'; runtime uses 'message'
+            if key == "msg":
+                entry["message"] = val
+            else:
+                entry[key] = val
+        resolved.append(entry)
     return resolved
 
 class Wrap:
@@ -144,7 +143,6 @@ class Wrap:
         pass
 
     fields = _Fields
-    default_field_watches = resolve_field_watches(_FIELD_WATCHES)
 
     ENTITY_GROUP_NAMES = {
         dcgm_fields.DCGM_FE_NONE: "None",

--- a/healthagent/bindings.py
+++ b/healthagent/bindings.py
@@ -80,7 +80,7 @@ def _resolve_error_codes_with_notes(*pairs):
 # (alias, dcgm_fields attribute name)
 _SYSTEM_FIELDS = [
     # Dev count — used by gpu_count_check
-    ("DEVCNT",           "DCGM_FI_DEV_CNT"),
+    ("DEVCNT",           "DCGM_FI_DEV_COUNT"),
     # Reference temps — used by __display_gpu_config / telemetry
     ("GPUTEMP_SLOWDOWN", "DCGM_FI_DEV_SLOWDOWN_TEMP"),
     ("GPUTEMP_SHUTDOWN",  "DCGM_FI_DEV_SHUTDOWN_TEMP"),

--- a/healthagent/config.py
+++ b/healthagent/config.py
@@ -66,15 +66,14 @@ class DiagPhase(BaseModel):
     params: str = ""
 
 
-class DiagnosticsConfig(BaseModel):
+class GpuDiagnosticCheckConfig(BaseModel):
     prolog: DiagPhase = DiagPhase()
     epilog: DiagPhase = DiagPhase(tests="medium")
 
 
 class GpuConfig(ModuleConfig):
-    max_keep_samples: int = 300
     xid: XidConfig = XidConfig()
-    diagnostics: DiagnosticsConfig = DiagnosticsConfig()
+    gpudiagnosticcheck: GpuDiagnosticCheckConfig = GpuDiagnosticCheckConfig()
     field_watches: dict[str, ThresholdCheck] = {}
 
 

--- a/healthagent/defaults.yaml
+++ b/healthagent/defaults.yaml
@@ -55,9 +55,6 @@ gpu:
     - nvidia-imex.service
     - nvidia-dcgm.service
     - nvidia-persistenced.service
-
-  max_keep_samples: 300
-
   # By default all XIDS are treated as error.
   # XIDS in warning list are downgraded to warning.
   # If error list is explicitly specified, then only
@@ -67,7 +64,9 @@ gpu:
     ignore: []
     error: []
 
-  diagnostics:
+
+
+  gpudiagnosticcheck:
     prolog:
       tests: short
       params: ""

--- a/healthagent/defaults.yaml
+++ b/healthagent/defaults.yaml
@@ -78,8 +78,7 @@ gpu:
   field_watches:
     DCGM_FI_DEV_GPU_TEMP:
       eval: gt
-      warning: 83
-      error: 90
+      warning: 93
       category: Thermal
       msg: "GPU {gpu} temperature {value}°C exceeds {threshold}°C"
     DCGM_FI_DEV_CLOCKS_EVENT_REASONS:
@@ -103,22 +102,21 @@ gpu:
       error: 0
       category: Memory
       msg: "GPU {gpu} row remap failure detected"
+    DCGM_FI_DEV_RETIRED_PENDING:
+      eval: gt
+      warning: 0
+      category: Memory
+      msg: "GPU {gpu} has pages pending retirement (reboot recommended)"
     DCGM_FI_DEV_ECC_DBE_VOL_TOTAL:
       eval: gt
       error: 0
       category: Memory
       msg: "GPU {gpu} volatile DBE errors detected: {value}"
-    DCGM_FI_DEV_RETIRED_SBE:
+    DCGM_FI_DEV_NVLINK_COUNT_EFFECTIVE_BER_FLOAT:
       eval: gt
-      warning: 50
-      error: 63
-      category: Memory
-      msg: "GPU {gpu} retired SBE pages: {value} (threshold: {threshold})"
-    DCGM_FI_DEV_ECC_SBE_AGG_TOTAL:
-      eval: delta_gt
-      warning: 100
-      category: Memory
-      msg: "GPU {gpu} SBE rate {value:.0f}/min exceeds {threshold}/min"
+      warning: 1.0e-6
+      category: NVLink
+      msg: "GPU {gpu} NVLink effective BER {value:.2e} exceeds {threshold:.2e}"
     DCGM_FI_DEV_PCIE_REPLAY_COUNTER:
       eval: delta_gt
       warning: 50

--- a/healthagent/etc/epilog.sh.example
+++ b/healthagent/etc/epilog.sh.example
@@ -2,8 +2,7 @@
 ## Example slurm epilog script that can be used to drain nodes based on health status.
 ## It exits the node with the number of errors.
 ## Running healthagent epilog tests.
-
-response=$(/usr/bin/health -e)
+response=$(/usr/bin/health -e -c gpumemorycheck gpu_id=$SLURM_JOB_GPUS -c gpudiagnosticcheck gpu_id=$SLURM_JOB_GPUS)
 sum=$(echo $response | jq '[.gpu | to_entries[] | select(.value.status == "Error") | .value.error_count // 0] | add')
 if [[ $sum -ge 1 ]] ; then
     exit $sum

--- a/healthagent/etc/epilog.sh.example
+++ b/healthagent/etc/epilog.sh.example
@@ -3,7 +3,7 @@
 ## It exits the node with the number of errors.
 ## Running healthagent epilog tests.
 response=$(/usr/bin/health -e -c gpumemorycheck gpu_id=$SLURM_JOB_GPUS -c gpudiagnosticcheck gpu_id=$SLURM_JOB_GPUS)
-sum=$(echo $response | jq '[.gpu | to_entries[] | select(.value.status == "Error") | .value.error_count // 0] | add')
+sum=$(echo $response | jq '[.gpu | to_entries[] | select(.value.status == "Error") | .value.error_count // 1] | add')
 if [[ $sum -ge 1 ]] ; then
     exit $sum
 else

--- a/healthagent/etc/prolog.sh.example
+++ b/healthagent/etc/prolog.sh.example
@@ -1,0 +1,12 @@
+#!/bin/bash
+## Example slurm prolog script that can be used to reject job allocation and drain nodes based on health status.
+## It exits the node with the number of errors.
+## Running healthagent prolog tests.
+
+response=$(/usr/bin/health -p -c gpumemorycheck gpu_id=$SLURM_JOB_GPUS -c gpudiagnosticcheck gpu_id=$SLURM_JOB_GPUS)
+sum=$(echo $response | jq '[.gpu | to_entries[] | select(.value.status == "Error") | .value.error_count // 0] | add')
+if [[ $sum -ge 1 ]] ; then
+    exit $sum
+else
+    exit 0
+fi

--- a/healthagent/etc/prolog.sh.example
+++ b/healthagent/etc/prolog.sh.example
@@ -4,7 +4,7 @@
 ## Running healthagent prolog tests.
 
 response=$(/usr/bin/health -p -c gpumemorycheck gpu_id=$SLURM_JOB_GPUS -c gpudiagnosticcheck gpu_id=$SLURM_JOB_GPUS)
-sum=$(echo $response | jq '[.gpu | to_entries[] | select(.value.status == "Error") | .value.error_count // 0] | add')
+sum=$(echo $response | jq '[.gpu | to_entries[] | select(.value.status == "Error") | .value.error_count // 1] | add')
 if [[ $sum -ge 1 ]] ; then
     exit $sum
 else

--- a/healthagent/gpu.py
+++ b/healthagent/gpu.py
@@ -13,6 +13,17 @@ from healthagent.bindings import *
 
 log = logging.getLogger('healthagent')
 
+# Maximum number of samples to retain per field per entity.
+# At 1s polling, 300 = 5-minute window for delta_gt rate computation.
+MAX_KEEP_SAMPLES = 300
+
+# Field-specific enrichments: map field ID -> callable(raw_value, field_values) -> list[str].
+# Applied *after* generic message formatting to decode field values into
+# human-readable details. Independent of watch config (defaults or user overrides).
+_FIELD_ENRICHMENTS = {
+    dcgm_fields.DCGM_FI_DEV_CLOCKS_EVENT_REASONS: Wrap.get_throttle_reasons,
+}
+
 class GpuHealthChecksException(Exception):
     pass
 
@@ -72,14 +83,19 @@ class GpuHealthChecks(HealthModule):
     def setup_background_watches(self):
         """
         Setup field watches and health watches.
+        Registers system fields (reference, XID) + watch fields (health evaluation)
+        with DCGM for polling.
         """
-        self.watch_fields = Wrap.get_fields()
-        self.field_group = DcgmFieldGroup.DcgmFieldGroup(self.dcgmHandle, name="ccfield_group", fieldIds=self.watch_fields)
+        system_fields = Wrap.get_fields()
+        watch_fields = [w["field_id"] for w in Wrap.default_field_watches]
+        all_fields = list(dict.fromkeys(system_fields + watch_fields))
+        self.field_group = DcgmFieldGroup.DcgmFieldGroup(self.dcgmHandle, name="ccfield_group", fieldIds=all_fields)
         # UpdateFreq is in microseconds. So we are updating every 1 second.
-        # maxKeepSamples=300 bounds memory. We read the latest value each cycle.
-        self.dcgmGroup.samples.WatchFields(fieldGroup=self.field_group, updateFreq=1000000, maxKeepAge=0, maxKeepSamples=300)
+        self.dcgmGroup.samples.WatchFields(fieldGroup=self.field_group, updateFreq=1000000, maxKeepAge=0, maxKeepSamples=MAX_KEEP_SAMPLES)
         ## Add the health watches
         self.dcgmGroup.health.Set(Wrap.get_health_mask())
+        # Seed the persistent sample collection (first call with None returns latest values)
+        self._field_collection = self.dcgmGroup.samples.GetAllSinceLastCall_v2(None, self.field_group)
 
     def __display_gpu_config(self):
 
@@ -146,171 +162,92 @@ class GpuHealthChecks(HealthModule):
     def track_fieldsv2(self):
         """
         Generic field watch evaluation driven by Wrap.default_field_watches.
-        Reads DCGM field values and evaluates each watch against its thresholds.
-        XIDs are handled separately — not part of field watches.
+        Iterates all entity groups returned by DCGM. GPU entities get per-GPU
+        entries (GPU_0, GPU_1). Non-GPU entities report under 'overall'.
+        XIDs are handled separately — GPU-only, not part of field watches.
         """
         custom_fields = {'error_count': 0, 'category': set()}
         try:
-            response = self.dcgmGroup.samples.GetLatest_v2(self.field_group)
-            gpu_values = response.values.get(dcgm_fields.DCGM_FE_GPU, {})
-            for gpu in gpu_values:
-                gpu_id = f'GPU_{gpu}'
-                custom_fields.setdefault(gpu_id, self._gpu_entry())
+            # Accumulate new samples since last call
+            self._field_collection = self.dcgmGroup.samples.GetAllSinceLastCall_v2(
+                self._field_collection, self.field_group)
 
-                for watch in Wrap.default_field_watches:
-                    samples = gpu_values[gpu].get(watch["field_id"])
-                    if not samples or samples[0].isBlank:
-                        continue
+            # Trim each time series to MAX_KEEP_SAMPLES to bound memory
+            for entity_group_id, entities in self._field_collection.values.items():
+                for entity_id, fields in entities.items():
+                    for field_id, ts in fields.items():
+                        if len(ts.values) > MAX_KEEP_SAMPLES:
+                            ts.values = ts.values[-MAX_KEEP_SAMPLES:]
 
-                    newest, oldest = samples[0], samples[-1]
-                    severity = None
-                    threshold_used = None
-                    evaluated = None
-                    for level in ("error", "warning"):
-                        thresh = watch.get(level)
-                        if thresh is None:
+            for entity_group_id, entities in self._field_collection.values.items():
+                group_name = Wrap.ENTITY_GROUP_NAMES.get(entity_group_id, f"Entity_{entity_group_id}")
+                is_gpu = (entity_group_id == dcgm_fields.DCGM_FE_GPU)
+
+                for entity_id, field_values in entities.items():
+                    if is_gpu:
+                        entity_key = f"GPU_{entity_id}"
+                        custom_fields.setdefault(entity_key, self._gpu_entry())
+                    else:
+                        entity_key = "overall"
+                        custom_fields.setdefault(entity_key, {"errors": [], "warnings": []})
+
+                    for watch in Wrap.default_field_watches:
+                        samples = field_values.get(watch["field_id"])
+                        if not samples or samples[0].isBlank:
                             continue
-                        triggered, evaluated = evaluate(
-                            watch["eval"], newest.value, thresh,
-                            prev_value=oldest.value,
-                            prev_time=oldest.ts,
-                            current_time=newest.ts,
-                            window=watch.get("window", 60),
-                        )
-                        if triggered:
-                            severity = level
-                            threshold_used = thresh
-                            break
 
-                    if severity is None:
-                        continue
+                        newest, oldest = samples[-1], samples[0]
+                        #log.debug(f"Field {watch['field']} entity {entity_id}: {len(samples)} samples, oldest={oldest.value} ts={oldest.ts}, newest={newest.value} ts={newest.ts}")
+                        severity = None
+                        threshold_used = None
+                        evaluated = None
+                        for level in ("error", "warning"):
+                            thresh = watch.get(level)
+                            if thresh is None:
+                                continue
+                            triggered, evaluated = evaluate(
+                                watch["eval"], newest.value, thresh,
+                                prev_value=oldest.value,
+                                prev_time=oldest.ts / 1_000_000,
+                                current_time=newest.ts / 1_000_000,
+                                window=watch.get("window", 60),
+                            )
+                            if triggered:
+                                severity = level
+                                threshold_used = thresh
+                                break
 
-                    msg = watch["message"].format(gpu=gpu, value=evaluated, threshold=threshold_used)
-                    custom_fields[gpu_id]["errors" if severity == "error" else "warnings"].append(msg)
-                    if severity == "error":
-                        custom_fields['error_count'] += 1
-                    custom_fields['category'].add(watch["category"])
+                        if severity is None:
+                            continue
 
-                # XID - read latest, deduplicate by xid number per GPU, keep earliest timestamp
-                xid_samples = gpu_values[gpu].get(Wrap.fields.XID_ERRORS, [])
-                if gpu_id not in self.xid_history:
-                    self.xid_history[gpu_id] = {}
-                for sample in xid_samples:
-                    if not sample.isBlank:
-                        xid_num = sample.value
-                        ts_utc = datetime.fromtimestamp(sample.ts / 1_000_000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S UTC")
-                        if xid_num not in self.xid_history[gpu_id] or ts_utc < self.xid_history[gpu_id][xid_num]["timestamp"]:
-                            self.xid_history[gpu_id][xid_num] = {"xid": xid_num, "timestamp": ts_utc}
+                        if is_gpu:
+                            msg = watch["message"].format(gpu=entity_id, value=evaluated, threshold=threshold_used)
+                        else:
+                            msg = f"[{group_name}_{entity_id}] " + watch["message"].format(gpu=entity_id, value=evaluated, threshold=threshold_used)
 
-            # Populate report with full XID history
-            for gpu_id, xids in self.xid_history.items():
-                custom_fields.setdefault(gpu_id, self._gpu_entry())
-                for entry in xids.values():
-                    xid_num = entry["xid"]
-                    if xid_num in self.XID_IGNORE:
-                        severity = "ignore"
-                    elif xid_num in self.XID_WARNING:
-                        severity = "warning"
-                    else:
-                        severity = "error"
-                        custom_fields['error_count'] += 1
-                    custom_fields[gpu_id]['xid'].append({**entry, "severity": severity})
-                if xids:
-                    custom_fields['category'].add("XID")
+                        enrich = _FIELD_ENRICHMENTS.get(watch["field_id"])
+                        if enrich:
+                            details = enrich(newest.value, field_values)
+                            if details:
+                                msg += " \u2014 " + "; ".join(details)
 
-            return custom_fields
-        except Exception as e:
-            log.exception(e)
-            return custom_fields
-    def track_fields(self):
+                        custom_fields[entity_key]["errors" if severity == "error" else "warnings"].append(msg)
+                        if severity == "error":
+                            custom_fields['error_count'] += 1
+                        custom_fields['category'].add(watch["category"])
 
-        """
-        Read field values from DCGM.
-        All fields (polled and event-driven) are read via GetLatest_v2.
-        XIDs are deduplicated and accumulated in self.xid_history for the node's lifetime.
-        """
-
-        custom_fields = {}
-        custom_fields['error_count'] = 0
-        custom_fields['category'] = set()
-        try:
-            response = self.dcgmGroup.samples.GetLatest_v2(self.field_group)
-            gpu_values = response.values.get(dcgm_fields.DCGM_FE_GPU, {})
-            for gpu in gpu_values:
-                gpu_id = f'GPU_{gpu}'
-                custom_fields.setdefault(gpu_id, self._gpu_entry())
-                # Handle Thermal
-                curr_temp = gpu_values[gpu][Wrap.fields.GPUTEMP][0].value
-                slowdown_temp = gpu_values[gpu][Wrap.fields.GPUTEMP_SLOWDOWN][0].value
-                triggered, _ = evaluate("ge", curr_temp, 0.95 * slowdown_temp)
-                if triggered:
-                    msg = f"GPU temperature reached very close to the slowdown limit gpu: {gpu} Curr temp: {curr_temp}, slowdown limit: {slowdown_temp}"
-                    custom_fields[gpu_id]["errors"].append(msg)
-                    custom_fields['error_count'] += 1
-                    custom_fields['category'].add("Thermal")
-                # Clocks
-                clock_reason = gpu_values[gpu][Wrap.fields.CLOCK_REASON][0].value
-                THROTTLE_MASK = (dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_SLOWDOWN
-                                 | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_SW_THERMAL
-                                 | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_THERMAL
-                                 | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_POWER_BRAKE)
-                triggered, _ = evaluate("bitmask", clock_reason, THROTTLE_MASK)
-                if triggered:
-                    throttle_reasons = Wrap.get_throttle_reasons(clock_reason)
-                    custom_fields[gpu_id]["errors"].append(throttle_reasons)
-                    custom_fields['error_count'] += 1
-                    custom_fields['category'].add("Clocks")
-                # Fabric errors
-                fabric_status = gpu_values[gpu][Wrap.fields.FABRIC_STATUS][0].value
-                triggered, _ = evaluate("eq", fabric_status, dcgm_structs.DcgmFMStatusFailure)
-                if triggered:
-                    fabric_error = gpu_values[gpu][Wrap.fields.FABRIC_ERROR][0].value
-                    msg = f"Fabric Manager finished training but failed, error code: {fabric_error}"
-                    custom_fields[gpu_id]["errors"].append(msg)
-                    custom_fields['error_count'] += 1
-                    custom_fields['category'].add("FabricManager")
-                else:
-                    triggered, _ = evaluate("eq", fabric_status, dcgm_structs.DcgmFMStatusInProgress)
-                    if triggered:
-                        fabric_error = gpu_values[gpu][Wrap.fields.FABRIC_ERROR][0].value
-                        msg = f"Fabric Manager not running, training in progress, error code: {fabric_error}"
-                        custom_fields[gpu_id]["errors"].append(msg)
-                        custom_fields['error_count'] += 1
-                        custom_fields['category'].add("FabricManager")
-                # Persistence mode
-                persistence_mode = gpu_values[gpu][Wrap.fields.PERSISTENCE_MODE][0].value
-                triggered, _ = evaluate("ne", persistence_mode, 1)
-                if triggered:
-                    msg = f"Persistence Mode not set for GPU: {gpu}, Restart nvidia-persistenced or Reboot the system."
-                    custom_fields[gpu_id]["errors"].append(msg)
-                    custom_fields['error_count'] += 1
-                    custom_fields['category'].add("System")
-                # Row Remap failures
-                row_remap_failure = gpu_values[gpu][Wrap.fields.ROW_REMAP_FAIL][0].value
-                triggered, _ = evaluate("ne", row_remap_failure, 0)
-                if triggered:
-                    msg = f"GPU {gpu}: {dcgm_errors.DCGM_FR_ROW_REMAP_FAILURE_MSG} {dcgm_errors.DCGM_FR_ROW_REMAP_FAILURE_NEXT}"
-                    custom_fields[gpu_id]["errors"].append(msg)
-                    custom_fields['error_count'] += 1
-                    custom_fields['category'].add("Memory")
-                # DBE error
-                dbe_error = gpu_values[gpu][Wrap.fields.DBE_ERRORS][0].value
-                triggered, _ = evaluate("gt", dbe_error, 0)
-                if triggered:
-                    msg = f"{dcgm_errors.DCGM_FR_VOLATILE_DBE_DETECTED_MSG % (dbe_error, gpu)} {dcgm_errors.DCGM_FR_VOLATILE_DBE_DETECTED_NEXT}"
-                    custom_fields[gpu_id]["errors"].append(msg)
-                    custom_fields['error_count'] += 1
-                    custom_fields['category'].add("Memory")
-                # XID - read latest, deduplicate by xid number per GPU, keep earliest timestamp
-                xid_samples = gpu_values[gpu].get(Wrap.fields.XID_ERRORS, [])
-                if gpu_id not in self.xid_history:
-                    self.xid_history[gpu_id] = {}
-                for sample in xid_samples:
-                    if not sample.isBlank:
-                        xid_num = sample.value
-                        ts_utc = datetime.fromtimestamp(sample.ts / 1_000_000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S UTC")
-                        if xid_num not in self.xid_history[gpu_id] or ts_utc < self.xid_history[gpu_id][xid_num]["timestamp"]:
-                            self.xid_history[gpu_id][xid_num] = {"xid": xid_num, "timestamp": ts_utc}
+                    # XID handling — GPU entities only
+                    if is_gpu:
+                        xid_samples = field_values.get(Wrap.fields.XID_ERRORS, [])
+                        gpu_id = entity_key
+                        if gpu_id not in self.xid_history:
+                            self.xid_history[gpu_id] = {}
+                        for sample in xid_samples:
+                            if not sample.isBlank:
+                                xid_num = sample.value
+                                ts_utc = datetime.fromtimestamp(sample.ts / 1_000_000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S UTC")
+                                if xid_num not in self.xid_history[gpu_id] or ts_utc < self.xid_history[gpu_id][xid_num]["timestamp"]:
+                                    self.xid_history[gpu_id][xid_num] = {"xid": xid_num, "timestamp": ts_utc}
 
             # Populate report with full XID history
             for gpu_id, xids in self.xid_history.items():
@@ -332,6 +269,117 @@ class GpuHealthChecks(HealthModule):
         except Exception as e:
             log.exception(e)
             return custom_fields
+
+    # def track_fields(self):
+
+    #     """
+    #     Read field values from DCGM.
+    #     All fields (polled and event-driven) are read via GetLatest_v2.
+    #     XIDs are deduplicated and accumulated in self.xid_history for the node's lifetime.
+    #     """
+
+    #     custom_fields = {}
+    #     custom_fields['error_count'] = 0
+    #     custom_fields['category'] = set()
+    #     try:
+    #         response = self.dcgmGroup.samples.GetLatest_v2(self.field_group)
+    #         gpu_values = response.values.get(dcgm_fields.DCGM_FE_GPU, {})
+    #         for gpu in gpu_values:
+    #             gpu_id = f'GPU_{gpu}'
+    #             custom_fields.setdefault(gpu_id, self._gpu_entry())
+    #             # Handle Thermal
+    #             curr_temp = gpu_values[gpu][Wrap.fields.GPUTEMP][0].value
+    #             slowdown_temp = gpu_values[gpu][Wrap.fields.GPUTEMP_SLOWDOWN][0].value
+    #             triggered, _ = evaluate("ge", curr_temp, 0.95 * slowdown_temp)
+    #             if triggered:
+    #                 msg = f"GPU temperature reached very close to the slowdown limit gpu: {gpu} Curr temp: {curr_temp}, slowdown limit: {slowdown_temp}"
+    #                 custom_fields[gpu_id]["errors"].append(msg)
+    #                 custom_fields['error_count'] += 1
+    #                 custom_fields['category'].add("Thermal")
+    #             # Clocks
+    #             clock_reason = gpu_values[gpu][Wrap.fields.CLOCK_REASON][0].value
+    #             THROTTLE_MASK = (dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_SLOWDOWN
+    #                              | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_SW_THERMAL
+    #                              | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_THERMAL
+    #                              | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_POWER_BRAKE)
+    #             triggered, _ = evaluate("bitmask", clock_reason, THROTTLE_MASK)
+    #             if triggered:
+    #                 throttle_reasons = Wrap.get_throttle_reasons(clock_reason)
+    #                 custom_fields[gpu_id]["errors"].append(throttle_reasons)
+    #                 custom_fields['error_count'] += 1
+    #                 custom_fields['category'].add("Clocks")
+    #             # Fabric errors
+    #             fabric_status = gpu_values[gpu][Wrap.fields.FABRIC_STATUS][0].value
+    #             triggered, _ = evaluate("eq", fabric_status, dcgm_structs.DcgmFMStatusFailure)
+    #             if triggered:
+    #                 fabric_error = gpu_values[gpu][Wrap.fields.FABRIC_ERROR][0].value
+    #                 msg = f"Fabric Manager finished training but failed, error code: {fabric_error}"
+    #                 custom_fields[gpu_id]["errors"].append(msg)
+    #                 custom_fields['error_count'] += 1
+    #                 custom_fields['category'].add("FabricManager")
+    #             else:
+    #                 triggered, _ = evaluate("eq", fabric_status, dcgm_structs.DcgmFMStatusInProgress)
+    #                 if triggered:
+    #                     fabric_error = gpu_values[gpu][Wrap.fields.FABRIC_ERROR][0].value
+    #                     msg = f"Fabric Manager not running, training in progress, error code: {fabric_error}"
+    #                     custom_fields[gpu_id]["errors"].append(msg)
+    #                     custom_fields['error_count'] += 1
+    #                     custom_fields['category'].add("FabricManager")
+    #             # Persistence mode
+    #             persistence_mode = gpu_values[gpu][Wrap.fields.PERSISTENCE_MODE][0].value
+    #             triggered, _ = evaluate("ne", persistence_mode, 1)
+    #             if triggered:
+    #                 msg = f"Persistence Mode not set for GPU: {gpu}, Restart nvidia-persistenced or Reboot the system."
+    #                 custom_fields[gpu_id]["errors"].append(msg)
+    #                 custom_fields['error_count'] += 1
+    #                 custom_fields['category'].add("System")
+    #             # Row Remap failures
+    #             row_remap_failure = gpu_values[gpu][Wrap.fields.ROW_REMAP_FAIL][0].value
+    #             triggered, _ = evaluate("ne", row_remap_failure, 0)
+    #             if triggered:
+    #                 msg = f"GPU {gpu}: {dcgm_errors.DCGM_FR_ROW_REMAP_FAILURE_MSG} {dcgm_errors.DCGM_FR_ROW_REMAP_FAILURE_NEXT}"
+    #                 custom_fields[gpu_id]["errors"].append(msg)
+    #                 custom_fields['error_count'] += 1
+    #                 custom_fields['category'].add("Memory")
+    #             # DBE error
+    #             dbe_error = gpu_values[gpu][Wrap.fields.DBE_ERRORS][0].value
+    #             triggered, _ = evaluate("gt", dbe_error, 0)
+    #             if triggered:
+    #                 msg = f"{dcgm_errors.DCGM_FR_VOLATILE_DBE_DETECTED_MSG % (dbe_error, gpu)} {dcgm_errors.DCGM_FR_VOLATILE_DBE_DETECTED_NEXT}"
+    #                 custom_fields[gpu_id]["errors"].append(msg)
+    #                 custom_fields['error_count'] += 1
+    #                 custom_fields['category'].add("Memory")
+    #             # XID - read latest, deduplicate by xid number per GPU, keep earliest timestamp
+    #             xid_samples = gpu_values[gpu].get(Wrap.fields.XID_ERRORS, [])
+    #             if gpu_id not in self.xid_history:
+    #                 self.xid_history[gpu_id] = {}
+    #             for sample in xid_samples:
+    #                 if not sample.isBlank:
+    #                     xid_num = sample.value
+    #                     ts_utc = datetime.fromtimestamp(sample.ts / 1_000_000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S UTC")
+    #                     if xid_num not in self.xid_history[gpu_id] or ts_utc < self.xid_history[gpu_id][xid_num]["timestamp"]:
+    #                         self.xid_history[gpu_id][xid_num] = {"xid": xid_num, "timestamp": ts_utc}
+
+    #         # Populate report with full XID history
+    #         for gpu_id, xids in self.xid_history.items():
+    #             custom_fields.setdefault(gpu_id, self._gpu_entry())
+    #             for entry in xids.values():
+    #                 xid_num = entry["xid"]
+    #                 if xid_num in self.XID_IGNORE:
+    #                     severity = "ignore"
+    #                 elif xid_num in self.XID_WARNING:
+    #                     severity = "warning"
+    #                 else:
+    #                     severity = "error"
+    #                     custom_fields['error_count'] += 1
+    #                 custom_fields[gpu_id]['xid'].append({**entry, "severity": severity})
+    #             if xids:
+    #                 custom_fields['category'].add("XID")
+
+    #         return custom_fields
+    #     except Exception as e:
+    #         log.exception(e)
+    #         return custom_fields
 
     @healthcheck("GpuMemoryCheck", args=["gpu_id"], description="Run GPU memory allocation test. Args: gpu_id=0,1")
     @epilog
@@ -409,13 +457,14 @@ class GpuHealthChecks(HealthModule):
                 group_health = self.dcgmGroup.health.Check()
                 incident_count = group_health.incidentCount
 
-                custom_fields = self.track_fields()
+                custom_fields = self.track_fieldsv2()
                 if custom_fields.get('error_count', 0) > 0:
                     report.escalate(HealthStatus.ERROR)
 
                 for index in range (0, incident_count):
                     entity_id = group_health.incidents[index].entityInfo.entityId
-                    if entity_id == dcgm_fields.DCGM_FE_GPU:
+                    entity_group_id = group_health.incidents[index].entityInfo.entityGroupId
+                    if entity_group_id == dcgm_fields.DCGM_FE_GPU:
                         entity = f"GPU_{entity_id}"
                         custom_fields.setdefault(entity, self._gpu_entry())
                     else:
@@ -436,7 +485,7 @@ class GpuHealthChecks(HealthModule):
                         #ignore
                         continue
 
-                #details.extend(field_errors)
+                # TRIM the output for better readability.
                 custom_fields['category'].update(subsystems)
                 report.custom_fields = {
                     k: v for k, v in custom_fields.items()
@@ -466,8 +515,8 @@ class GpuHealthChecks(HealthModule):
             try:
                 self.setup()
             except Wrap.DcgmConnectionFail as e:
-                log.critical(f"Unable to connect to DCGM: {e}")
-                log.critical("To re-instantiate checks, restart the nvidia-dcgm service.")
+                log.critical(f"Unable to instantiate or connect to DCGM: {e}")
+                log.critical("To re-instantiate checks, restart healthagent. If using DCGM_TEST_MODE, restart nvidia-dcgm.service")
             else:
                 log.info("Re-initialized our connection to DCGM.")
         except Exception as e:

--- a/healthagent/gpu.py
+++ b/healthagent/gpu.py
@@ -4,7 +4,7 @@ import logging
 import os
 import shutil
 from datetime import datetime, timezone
-from healthagent import epilog,status,healthcheck
+from healthagent import epilog,status,healthcheck,prolog
 from healthagent.scheduler import Scheduler
 from healthagent.healthmodule import HealthModule
 from healthagent.reporter import Reporter, HealthReport,HealthStatus
@@ -243,6 +243,7 @@ class GpuHealthChecks(HealthModule):
 
     @healthcheck("GpuMemoryCheck", args=["gpu_id"], description="Run GPU memory allocation test. Args: gpu_id=0,1")
     @epilog
+    @prolog
     async def memory_allocation_test(self, gpu_id: list = None):
         health_system = self.memory_allocation_test.report_name
         report = HealthReport()
@@ -277,11 +278,19 @@ class GpuHealthChecks(HealthModule):
         response[health_system] = report.view()
         return response
 
-    @healthcheck("GpuDiagnosticCheck", description="Run dcgm diagnostics checks")
+    DIAG_DEFAULTS = {
+        "prolog": {"tests": "short", "params": ""},
+        "epilog": {"tests": "medium", "params": ""},
+    }
+    @healthcheck("GpuDiagnosticCheck", description="Run DCGM diagnostics checks. Eg. Args: gpu_id=0,1 tests=memory", args=['gpu_id','tests', 'params'])
     @epilog
-    async def run_epilog(self):
-        health_system = self.run_epilog.report_name
-        report = await Scheduler.add_task(run_active_healthchecksv2)
+    @prolog
+    async def run_diag(self, gpu_id: list = None, tests: str = '', params: str = '', _phase: str = None):
+        phase_defaults = self.DIAG_DEFAULTS.get(_phase, {})
+        tests = tests or phase_defaults.get("tests", "")
+        params = params or phase_defaults.get("params", "")
+        health_system = self.run_diag.report_name
+        report = await Scheduler.add_task(run_active_healthchecksv2, gpu_id=gpu_id, tests=tests, params=params)
         await self.reporter.update_report(name=health_system, report=report)
         response = {}
         response[health_system] = report.view()
@@ -390,7 +399,7 @@ def _diag_entry():
     return {"errors": [], "warnings": [], "suppressed": []}
 
 @Scheduler.pool
-def run_active_healthchecksv2():
+def run_active_healthchecksv2(gpu_id: list = None, tests: str = '', params: str = ''):
 
     """
     Run active healthchecks, before or after a job.
@@ -410,11 +419,12 @@ def run_active_healthchecksv2():
         diag_log = os.path.join(log_dir, "nvvs_diag.log")
 
         dcgmGroup, dcgmHandle = Wrap.connect(grp_name="epilog")
-        gpu_ids = dcgmGroup.GetGpuIds()
-        params = "memory.minimum_allocation_percentage=90;memory.is_allowed=true"
-        #TODO: Later we can make this list come based on background health check errors. For example, only run pcie test if we detected pcie issues.
-        tests = "memory,pcie"
-        dd = DcgmDiag.DcgmDiag(gpuIds=gpu_ids, testNamesStr=tests, paramsStr=params)
+        if gpu_id is None:
+            gpu_id = dcgmGroup.GetGpuIds()
+
+        #params = "memory.minimum_allocation_percentage=90;memory.is_allowed=true"
+        #tests = "software,memory,pcie"
+        dd = DcgmDiag.DcgmDiag(gpuIds=gpu_id, testNamesStr=tests, paramsStr=params)
 
         if os.path.exists(log_dir):
             # Rotate if file is too large ( > 50MB)

--- a/healthagent/gpu.py
+++ b/healthagent/gpu.py
@@ -3,7 +3,7 @@ import sys
 import logging
 import os
 import shutil
-from datetime import datetime
+from datetime import datetime, timezone
 from healthagent import epilog,status,healthcheck
 from healthagent.scheduler import Scheduler
 from healthagent.healthmodule import HealthModule
@@ -45,6 +45,7 @@ class GpuHealthChecks(HealthModule):
         self.dcgmHandle = None
         self.watch_fields = []
         self.gpu_config = []
+        self.xid_history = {}
         if self.test_mode:
             log.info("Running GPU tests in DCGM_TEST_MODE")
         self.dcgmGroup, self.dcgmHandle = Wrap.connect(grp_name="healthagent_group", test_mode=self.test_mode)
@@ -61,7 +62,7 @@ class GpuHealthChecks(HealthModule):
         """
 
         # TODO: These limits will come from a configuration file eventually.
-        policy = Wrap.set_policy(mpe=8)
+        policy = Wrap.set_policy()
         self.dcgmGroup.policy.Set(policy)
         self.c_callback = create_c_callback(self.handle_policy_violation, asyncio.get_running_loop())
         self.dcgmGroup.policy.Register(policy.condition, self.c_callback, None)
@@ -71,16 +72,11 @@ class GpuHealthChecks(HealthModule):
         """
         Setup field watches and health watches.
         """
-        # TODO: Add more fields to watch fields in addition to policy fields
-        # but for now just add policy fields.
         self.watch_fields = Wrap.get_fields()
-        self.field_group = DcgmFieldGroup.DcgmFieldGroup(self.dcgmHandle, name="ccfield_group_instant", fieldIds=self.watch_fields)
+        self.field_group = DcgmFieldGroup.DcgmFieldGroup(self.dcgmHandle, name="ccfield_group", fieldIds=self.watch_fields)
         # UpdateFreq is in microseconds. So we are updating every 1 second.
-        # MaxKeepAge:  is how long samples are stored in memory, in seconds. 0 means maxkeepsamples enforces the bounds.
-        # maxkeepsamples: how many samples are stored in DCGM Cache. For this particular field group, we only ever read the latest value. See function track_fields.
-        # Storing last 10 samples (or last 10 seconds of data) is more than enough and effectively  bounds the memory.
-        # If we need historical trending for a field group we will create a new field group with appropriate retention policies.
-        self.dcgmGroup.samples.WatchFields(fieldGroup=self.field_group, updateFreq=1000000, maxKeepAge=0, maxKeepSamples=10)
+        # maxKeepSamples=60 bounds memory. We read the latest value each cycle.
+        self.dcgmGroup.samples.WatchFields(fieldGroup=self.field_group, updateFreq=1000000, maxKeepAge=0, maxKeepSamples=60)
         ## Add the health watches
         self.dcgmGroup.health.Set(Wrap.get_health_mask())
 
@@ -117,135 +113,133 @@ class GpuHealthChecks(HealthModule):
         Scheduler.add_task(self.gpu_count_check)
         Scheduler.add_task(self.run_background_healthchecks)
 
-    @healthcheck("GpuPolicyCheck", description="GPU policy violation checks")
     async def handle_policy_violation(self, callbackresp):
 
-        health_system = self.handle_policy_violation.report_name
-        report = self.reporter.get_report(health_system) or HealthReport()
         condition = callbackresp.condition
-        gpuid = callbackresp.gpuId
-        harmless_xid = [ 43, 63 ]
         try:
             condition_str = Wrap.dcgm_condition_to_string(condition=condition)
+            if condition == dcgm_structs.DCGM_POLICY_COND_XID:
+                gpuid = callbackresp.gpuId
+                xid_received = callbackresp.val.xid.errnum
+                unix_ts = callbackresp.val.xid.timestamp
+                timestamp = datetime.fromtimestamp(unix_ts / 1_000_000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S UTC")
+                log.critical("XID detected: %d  on gpu: %d" % (xid_received, gpuid))
+                gpu_key = f'GPU_{gpuid}'
+                if gpu_key not in self.xid_history:
+                    self.xid_history[gpu_key] = {}
+                if xid_received not in self.xid_history[gpu_key] or timestamp < self.xid_history[gpu_key][xid_received]["timestamp"]:
+                    self.xid_history[gpu_key][xid_received] = {"xid": xid_received, "timestamp": timestamp}
         except ValueError as e:
             log.exception(e)
             return
 
-        log.critical("Violation detected: %s  on gpu: %d" % (condition_str, gpuid))
+    # TODO: Adding all config file attributes as class objects for now.
+    XID_WARNING = [43, 63, 13, 31, 66, 94, 154]
+    XID_IGNORE = []
+    XID_ERROR = []
 
-        if condition_str not in report.custom_fields:
-            report.custom_fields[condition_str] = {}
-            # violation data is a 2D dict containing violation results indexed by condition and gpu id. vd[condition][gpuid]
-            vd = {}
-        else:
-            vd = report.custom_fields[condition_str]
-
-        #vd['timestamp'] = condition.val.timestamp
-        if gpuid not in vd:
-            vd[gpuid] = {}
-
-        info = vd[gpuid]
-        if condition == dcgm_structs.DCGM_POLICY_COND_DBE:
-            if 'location' not in info:
-                info['location'] = set()
-            info['location'].add(next(key for key, value in dcgm_structs.c_dcgmPolicyConditionDbe_t.LOCATIONS.items() if value == callbackresp.val.dbe.location))
-            info['numerrors'] = callbackresp.val.dbe.numerrors
-            info['details'] = f"Double-Bit ECC errors({info['numerrors']}) found at location: {info['location']} on GPU: {gpuid}"
-            report.escalate(HealthStatus.ERROR)
-        elif condition == dcgm_structs.DCGM_POLICY_COND_PCI:
-            info['replay_count'] = callbackresp.val.pci.counter
-            info['details'] = f"PCI replay count({info['replay_count']}) on GPU: {gpuid}"
-            report.escalate(HealthStatus.ERROR)
-        elif condition == dcgm_structs.DCGM_POLICY_COND_NVLINK:
-            info['error_count'] = callbackresp.val.nvlink.counter
-            if 'field_id' not in info:
-                info['field_id'] = set()
-            info['field_id'].add(callbackresp.val.nvlink.fieldId)
-            info['details'] = f"Nvlink violation on GPU: {gpuid}"
-            report.escalate(HealthStatus.ERROR)
-        elif condition == dcgm_structs.DCGM_POLICY_COND_XID:
-            if 'xid_error' not in info:
-                info['xid_error'] = set()
-            info['xid_error'].add(callbackresp.val.xid.errnum)
-            info['details'] = f"XID errors found: XID {info['xid_error']} on GPU {gpuid}"
-            # Harmless XIDs are warnings; others are errors
-            if info['xid_error'].issubset(set(harmless_xid)):
-                report.escalate(HealthStatus.WARNING)
-            else:
-                report.escalate(HealthStatus.ERROR)
-        # elif condition == dcgm_structs.DCGM_POLICY_COND_THERMAL:
-        #     report.escalate(HealthStatus.WARNING)
-        #     info['temperature'] = callbackresp.val.thermal.thermalViolation
-        #     info['details'] = f"Thermal violation detected: Temperature reached {info['temperature']} Celsius GPU: {gpuid}"
-        # elif condition == dcgm_structs.DCGM_POLICY_COND_POWER:
-        #     report.escalate(HealthStatus.WARNING)
-        #     info['power'] = callbackresp.val.power.powerViolation
-        #     info['details'] = f"Power violation detected: Power draw {info['power']} Watts GPU: {gpuid}"
-        elif condition == dcgm_structs.DCGM_POLICY_COND_MAX_PAGES_RETIRED:
-            info['sbepage_count'] = callbackresp.val.mpr.sbepages
-            info['dbepage_count'] = callbackresp.val.mpr.dbepages
-            info['details'] = f"Max retired pages violation: SBE retired pages: {info['sbepage_count']}, DBE retired pages {info['dbepage_count']} GPU: {gpuid}"
-            report.escalate(HealthStatus.ERROR)
-
-        vd[gpuid] = info
-        report.custom_fields[condition_str] = vd
-        report.description = "GPU Policy Violations detected"
-        if not report.details:
-            report.details = info['details']
-        else:
-            # regenerate
-            report.details = ""
-            for condition in report.custom_fields:
-                for gpu in report.custom_fields[condition]:
-                    report.details += f"\n{report.custom_fields[condition][gpu]['details']}"
-        await self.reporter.update_report(name=health_system, report=report)
-        return
-
+    @staticmethod
+    def _gpu_entry():
+        return {"errors": [], "warnings": [], "xid": []}
 
     def track_fields(self):
 
         """
         Read field values from DCGM.
+        All fields (polled and event-driven) are read via GetLatest_v2.
+        XIDs are deduplicated and accumulated in self.xid_history for the node's lifetime.
         """
 
-        errors = []
-        category = []
+        custom_fields = {}
+        custom_fields['error_count'] = 0
+        custom_fields['category'] = set()
         try:
-            response = self.dcgmGroup.samples.GetLatest(self.field_group)
-            for gpu in response.values:
-
-                curr_temp = response.values[gpu][Wrap.fields.GPUTEMP][0].value
-                slowdown_temp = response.values[gpu][Wrap.fields.GPUTEMP_SLOWDOWN][0].value
+            response = self.dcgmGroup.samples.GetLatest_v2(self.field_group)
+            gpu_values = response.values.get(dcgm_fields.DCGM_FE_GPU, {})
+            for gpu in gpu_values:
+                gpu_id = f'GPU_{gpu}'
+                custom_fields.setdefault(gpu_id, self._gpu_entry())
+                # Handle Thermal
+                curr_temp = gpu_values[gpu][Wrap.fields.GPUTEMP][0].value
+                slowdown_temp = gpu_values[gpu][Wrap.fields.GPUTEMP_SLOWDOWN][0].value
                 if curr_temp >= (0.95*slowdown_temp):
                     msg = f"GPU temperature reached very close to the slowdown limit gpu: {gpu} Curr temp: {curr_temp}, slowdown limit: {slowdown_temp}"
-                    errors.append(msg)
-                    category.append("Thermal")
-
-                clock_reason = response.values[gpu][Wrap.fields.CLOCK_REASON][0].value
+                    custom_fields[gpu_id]["errors"].append(msg)
+                    custom_fields['error_count'] += 1
+                    custom_fields['category'].add("Thermal")
+                # Clocks
+                clock_reason = gpu_values[gpu][Wrap.fields.CLOCK_REASON][0].value
                 throttle_reasons = Wrap.get_throttle_reasons(clock_reason)
                 if throttle_reasons:
-                    errors.extend(throttle_reasons)
-                    category.append("Clocks")
-                fabric_status = response.values[gpu][Wrap.fields.FABRIC_STATUS][0].value
+                    custom_fields[gpu_id]["errors"].append(throttle_reasons)
+                    custom_fields['error_count'] += 1
+                    custom_fields['category'].add("Clocks")
+                # Fabric errors
+                fabric_status = gpu_values[gpu][Wrap.fields.FABRIC_STATUS][0].value
                 if fabric_status == dcgm_structs.DcgmFMStatusFailure:
-                    fabric_error = response.values[gpu][Wrap.fields.FABRIC_ERROR][0].value
+                    fabric_error = gpu_values[gpu][Wrap.fields.FABRIC_ERROR][0].value
                     msg = f"Fabric Manager finished training but failed, error code: {fabric_error}"
-                    errors.append(msg)
-                    category.append("FabricManager")
+                    custom_fields[gpu_id]["errors"].append(msg)
+                    custom_fields['error_count'] += 1
+                    custom_fields['category'].add("FabricManager")
                 elif fabric_status == dcgm_structs.DcgmFMStatusInProgress:
-                    fabric_error = response.values[gpu][Wrap.fields.FABRIC_ERROR][0].value
+                    fabric_error = gpu_values[gpu][Wrap.fields.FABRIC_ERROR][0].value
                     msg = f"Fabric Manager not running, training in progress, error code: {fabric_error}"
-                    errors.append(msg)
-                    category.append("FabricManager")
-                persistence_mode = response.values[gpu][Wrap.fields.PERSISTENCE_MODE][0].value
+                    custom_fields[gpu_id]["errors"].append(msg)
+                    custom_fields['error_count'] += 1
+                    custom_fields['category'].add("FabricManager")
+                # Persistence mode
+                persistence_mode = gpu_values[gpu][Wrap.fields.PERSISTENCE_MODE][0].value
                 if persistence_mode != 1:
                     msg = f"Persistence Mode not set for GPU: {gpu}, Restart nvidia-persistenced or Reboot the system."
-                    errors.append(msg)
-                    category.append("System")
+                    custom_fields[gpu_id]["errors"].append(msg)
+                    custom_fields['error_count'] += 1
+                    custom_fields['category'].add("System")
+                # Row Remap failures
+                row_remap_failure = gpu_values[gpu][Wrap.fields.ROW_REMAP_FAIL][0].value
+                if row_remap_failure:
+                    msg = f"GPU {gpu}: {dcgm_errors.DCGM_FR_ROW_REMAP_FAILURE_MSG} {dcgm_errors.DCGM_FR_ROW_REMAP_FAILURE_NEXT}"
+                    custom_fields[gpu_id]["errors"].append(msg)
+                    custom_fields['error_count'] += 1
+                    custom_fields['category'].add("Memory")
+                # DBE error
+                dbe_error = gpu_values[gpu][Wrap.fields.DBE_ERRORS][0].value
+                if dbe_error > 0:
+                    msg = f"{dcgm_errors.DCGM_FR_VOLATILE_DBE_DETECTED_MSG % (dbe_error, gpu)} {dcgm_errors.DCGM_FR_VOLATILE_DBE_DETECTED_NEXT}"
+                    custom_fields[gpu_id]["errors"].append(msg)
+                    custom_fields['error_count'] += 1
+                    custom_fields['category'].add("Memory")
+                # XID - read latest, deduplicate by xid number per GPU, keep earliest timestamp
+                xid_samples = gpu_values[gpu].get(Wrap.fields.XID_ERRORS, [])
+                if gpu_id not in self.xid_history:
+                    self.xid_history[gpu_id] = {}
+                for sample in xid_samples:
+                    if not sample.isBlank:
+                        xid_num = sample.value
+                        ts_utc = datetime.fromtimestamp(sample.ts / 1_000_000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S UTC")
+                        if xid_num not in self.xid_history[gpu_id] or ts_utc < self.xid_history[gpu_id][xid_num]["timestamp"]:
+                            self.xid_history[gpu_id][xid_num] = {"xid": xid_num, "timestamp": ts_utc}
 
-            return errors, category
+            # Populate report with full XID history
+            for gpu_id, xids in self.xid_history.items():
+                custom_fields.setdefault(gpu_id, self._gpu_entry())
+                for entry in xids.values():
+                    xid_num = entry["xid"]
+                    if xid_num in self.XID_IGNORE:
+                        severity = "ignore"
+                    elif xid_num in self.XID_WARNING:
+                        severity = "warning"
+                    else:
+                        severity = "error"
+                        custom_fields['error_count'] += 1
+                    custom_fields[gpu_id]['xid'].append({**entry, "severity": severity})
+                if xids:
+                    custom_fields['category'].add("XID")
+
+            return custom_fields
         except Exception as e:
             log.exception(e)
+            return custom_fields
 
     @healthcheck("GpuMemoryCheck", args=["gpu_id"], description="Run GPU memory allocation test. Args: gpu_id=0,1")
     @epilog
@@ -293,6 +287,7 @@ class GpuHealthChecks(HealthModule):
         response[health_system] = report.view()
         return response
 
+
     @healthcheck("GpuHealthCheck", description="Periodic GPU health monitoring")
     @Scheduler.periodic(60)
     async def run_background_healthchecks(self):
@@ -313,37 +308,47 @@ class GpuHealthChecks(HealthModule):
                 group_health = self.dcgmGroup.health.Check()
                 incident_count = group_health.incidentCount
 
-                field_errors, category = self.track_fields()
-                if len(field_errors) > 0:
+                custom_fields = self.track_fields()
+                if custom_fields.get('error_count', 0) > 0:
                     report.escalate(HealthStatus.ERROR)
-                if report.status == HealthStatus.OK and incident_count == 0:
+
+                for index in range (0, incident_count):
+                    entity_id = group_health.incidents[index].entityInfo.entityId
+                    if entity_id == dcgm_fields.DCGM_FE_GPU:
+                        entity = f"GPU_{entity_id}"
+                        custom_fields.setdefault(entity, self._gpu_entry())
+                    else:
+                        entity = "overall"
+                        custom_fields.setdefault(entity, {"errors": [], "warnings": []})
+                    system = Wrap.convert_system_enum_to_system_name(group_health.incidents[index].system)
+                    error_code = group_health.incidents[index].error.code
+                    if error_code in Wrap.HEALTH_WARNINGS:
+                        custom_fields[entity]['warnings'].append(group_health.incidents[index].error.msg)
+                        report.escalate(HealthStatus.WARNING)
+                        subsystems.add(system)
+                    elif error_code in Wrap.HEALTH_ERRORS:
+                        report.escalate(HealthStatus.ERROR)
+                        custom_fields[entity]['errors'].append(group_health.incidents[index].error.msg)
+                        subsystems.add(system)
+                        custom_fields['error_count'] += 1
+                    else:
+                        #ignore
+                        continue
+
+                #details.extend(field_errors)
+                custom_fields['category'].update(subsystems)
+                report.custom_fields = {
+                    k: v for k, v in custom_fields.items()
+                    if not isinstance(v, dict) or any(v.values())
+                }
+
+                if custom_fields['error_count'] == 0:
                     await self.reporter.update_report(name=health_system, report=report)
                     return
 
-                for index in range (0, incident_count):
-                    gpu_id = group_health.incidents[index].entityInfo.entityId
-                    system = Wrap.convert_system_enum_to_system_name(group_health.incidents[index].system)
-                    error_code = group_health.incidents[index].error.code
-                    if error_code == dcgm_errors.DCGM_FR_NVLINK_EFFECTIVE_BER_THRESHOLD:
-                        report.escalate(HealthStatus.WARNING)
-                    else:
-                        incident_status = Wrap.convert_health_to_status(group_health.incidents[index].health)
-                        if incident_status == HealthStatus.NA:
-                            log.error(f"Invalid health status receieved {system}, {error_code}")
-                        elif incident_status != HealthStatus.NA:
-                            report.escalate(incident_status)
-                    subsystems.add(system)
-                    details.append(group_health.incidents[index].error.msg)
-
-                details.extend(field_errors)
-                subsystems.update(category)
-                incident_count += len(field_errors)
-                description = f"{health_system} report {report.status.value} count={incident_count} subsystem={', '.join(subsystems)}"
-                custom_fields['categories'] = subsystems
-                custom_fields['error_count'] = incident_count
+                description = f"{health_system} report {custom_fields['error_count']} errors of type {', '.join(custom_fields['category'])}"
                 report.description = description
                 report.details = '\n'.join(details)
-                report.custom_fields = custom_fields
                 await self.reporter.update_report(name=health_system, report=report)
                 return
 
@@ -381,6 +386,9 @@ class GpuHealthChecks(HealthModule):
             ## disconnect from the hostengine by deleting the DcgmHandle object
             del(self.dcgmHandle)
 
+def _diag_entry():
+    return {"errors": [], "warnings": [], "suppressed": []}
+
 @Scheduler.pool
 def run_active_healthchecksv2():
 
@@ -393,9 +401,8 @@ def run_active_healthchecksv2():
     isHealthy = True
     report = HealthReport()
     custom_fields = {}
-
-    failures = list()
-    info_msgs = list()
+    custom_fields['error_count'] = 0
+    response = None
     try:
         #TODO: Find a better way to get this directory later.
         log_dir = "/opt/healthagent"
@@ -433,46 +440,41 @@ def run_active_healthchecksv2():
         response = dd.Execute(handle=dcgmHandle.handle)
 
     except Wrap.DcgmConnectionFail as e:
-        failures.append(str(e))
         report = HealthReport(status=HealthStatus.WARNING, description="Active Tests not performed",
                               details=f"Active diagnostics not performed.\n {e}")
         return report
     except dcgm_structs.DCGMError as e:
-        failures.append(str(e))
+        isHealthy = False
+        custom_fields['error_count'] += 1
+        custom_fields.setdefault('overall', _diag_entry())
+        custom_fields['overall']['errors'].append(str(e))
 
-    test_types = set()
-    if response.numErrors > 0:
+    if response and response.numErrors > 0:
         isHealthy = False
         for errIdx in range(response.numErrors):
             curErr = response.errors[errIdx]
             error_msg = curErr.msg
-            if curErr.testId == dcgm_structs.DCGM_DIAG_RESPONSE_SYSTEM_ERROR:
-                testName = "System"
-                failures.append(f"System Error: {error_msg}")
-                test_types.add(testName)
-            elif curErr.entity.entityGroupId == dcgm_fields.DCGM_FE_GPU:
-                testName = response.tests[curErr.testId].name
-                gpuId = curErr.entity.entityId
-                failures.append(f"GPU: {gpuId}, Test name: {testName}, Error: {error_msg}")
-                test_types.add(testName)
+            error_code = curErr.code
+            if curErr.entity.entityGroupId == dcgm_fields.DCGM_FE_GPU:
+                entity_id = f"GPU_{curErr.entity.entityId}"
             else:
-                failures.append(f"Error: {error_msg}")
-    if response.numInfo > 0:
-        for i in range(response.numInfo):
-            info = response.info[i]
-            testName = response.tests[info.testId].name
-            info_msgs.append(f"Test: {testName}, Info: {info.msg}")
-
+                entity_id = "overall"
+            custom_fields.setdefault(entity_id, _diag_entry())
+            if error_code in Wrap.DIAG_ERRORS:
+                custom_fields[entity_id]['errors'].append(error_msg)
+                custom_fields['error_count'] += 1
+                report.escalate(HealthStatus.ERROR)
+            elif error_code in Wrap.DIAG_WARNINGS:
+                note = Wrap.DIAG_WARNINGS[error_code]
+                custom_fields[entity_id]['warnings'].append({"msg": error_msg, "note": note})
+                report.escalate(HealthStatus.WARNING)
+            elif error_code in Wrap.DIAG_IGNORE:
+                continue
+            else:
+                custom_fields[entity_id]['suppressed'].append({"msg": error_msg, "note": Wrap.DIAG_SUPPRESSED_NOTE})
     if not isHealthy:
-        custom_fields['failures'] = test_types
-        custom_fields['error_count'] = len(failures)
-        custom_fields['info'] = info_msgs
-        report.status = HealthStatus.ERROR
-        report.details = "\n".join(failures)
-        if test_types:
-            report.description = f"DCGM Epilog failures in {', '.join(test_types)}"
-        else:
-            report.description = "DCGM Epilog failures detected"
+        #report.details = "\n".join(failures)
+        report.description = "Active Diagnostic test failures"
         report.message = "GPU Epilog Errors"
         report.custom_fields = custom_fields
 

--- a/healthagent/gpu.py
+++ b/healthagent/gpu.py
@@ -8,6 +8,7 @@ from healthagent import epilog,status,healthcheck,prolog
 from healthagent.scheduler import Scheduler
 from healthagent.healthmodule import HealthModule
 from healthagent.reporter import Reporter, HealthReport,HealthStatus
+from healthagent.util import evaluate
 from healthagent.bindings import *
 
 log = logging.getLogger('healthagent')
@@ -75,8 +76,8 @@ class GpuHealthChecks(HealthModule):
         self.watch_fields = Wrap.get_fields()
         self.field_group = DcgmFieldGroup.DcgmFieldGroup(self.dcgmHandle, name="ccfield_group", fieldIds=self.watch_fields)
         # UpdateFreq is in microseconds. So we are updating every 1 second.
-        # maxKeepSamples=60 bounds memory. We read the latest value each cycle.
-        self.dcgmGroup.samples.WatchFields(fieldGroup=self.field_group, updateFreq=1000000, maxKeepAge=0, maxKeepSamples=60)
+        # maxKeepSamples=300 bounds memory. We read the latest value each cycle.
+        self.dcgmGroup.samples.WatchFields(fieldGroup=self.field_group, updateFreq=1000000, maxKeepAge=0, maxKeepSamples=300)
         ## Add the health watches
         self.dcgmGroup.health.Set(Wrap.get_health_mask())
 
@@ -142,6 +143,85 @@ class GpuHealthChecks(HealthModule):
     def _gpu_entry():
         return {"errors": [], "warnings": [], "xid": []}
 
+    def track_fieldsv2(self):
+        """
+        Generic field watch evaluation driven by Wrap.default_field_watches.
+        Reads DCGM field values and evaluates each watch against its thresholds.
+        XIDs are handled separately — not part of field watches.
+        """
+        custom_fields = {'error_count': 0, 'category': set()}
+        try:
+            response = self.dcgmGroup.samples.GetLatest_v2(self.field_group)
+            gpu_values = response.values.get(dcgm_fields.DCGM_FE_GPU, {})
+            for gpu in gpu_values:
+                gpu_id = f'GPU_{gpu}'
+                custom_fields.setdefault(gpu_id, self._gpu_entry())
+
+                for watch in Wrap.default_field_watches:
+                    samples = gpu_values[gpu].get(watch["field_id"])
+                    if not samples or samples[0].isBlank:
+                        continue
+
+                    newest, oldest = samples[0], samples[-1]
+                    severity = None
+                    threshold_used = None
+                    evaluated = None
+                    for level in ("error", "warning"):
+                        thresh = watch.get(level)
+                        if thresh is None:
+                            continue
+                        triggered, evaluated = evaluate(
+                            watch["eval"], newest.value, thresh,
+                            prev_value=oldest.value,
+                            prev_time=oldest.ts,
+                            current_time=newest.ts,
+                            window=watch.get("window", 60),
+                        )
+                        if triggered:
+                            severity = level
+                            threshold_used = thresh
+                            break
+
+                    if severity is None:
+                        continue
+
+                    msg = watch["message"].format(gpu=gpu, value=evaluated, threshold=threshold_used)
+                    custom_fields[gpu_id]["errors" if severity == "error" else "warnings"].append(msg)
+                    if severity == "error":
+                        custom_fields['error_count'] += 1
+                    custom_fields['category'].add(watch["category"])
+
+                # XID - read latest, deduplicate by xid number per GPU, keep earliest timestamp
+                xid_samples = gpu_values[gpu].get(Wrap.fields.XID_ERRORS, [])
+                if gpu_id not in self.xid_history:
+                    self.xid_history[gpu_id] = {}
+                for sample in xid_samples:
+                    if not sample.isBlank:
+                        xid_num = sample.value
+                        ts_utc = datetime.fromtimestamp(sample.ts / 1_000_000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S UTC")
+                        if xid_num not in self.xid_history[gpu_id] or ts_utc < self.xid_history[gpu_id][xid_num]["timestamp"]:
+                            self.xid_history[gpu_id][xid_num] = {"xid": xid_num, "timestamp": ts_utc}
+
+            # Populate report with full XID history
+            for gpu_id, xids in self.xid_history.items():
+                custom_fields.setdefault(gpu_id, self._gpu_entry())
+                for entry in xids.values():
+                    xid_num = entry["xid"]
+                    if xid_num in self.XID_IGNORE:
+                        severity = "ignore"
+                    elif xid_num in self.XID_WARNING:
+                        severity = "warning"
+                    else:
+                        severity = "error"
+                        custom_fields['error_count'] += 1
+                    custom_fields[gpu_id]['xid'].append({**entry, "severity": severity})
+                if xids:
+                    custom_fields['category'].add("XID")
+
+            return custom_fields
+        except Exception as e:
+            log.exception(e)
+            return custom_fields
     def track_fields(self):
 
         """
@@ -162,49 +242,61 @@ class GpuHealthChecks(HealthModule):
                 # Handle Thermal
                 curr_temp = gpu_values[gpu][Wrap.fields.GPUTEMP][0].value
                 slowdown_temp = gpu_values[gpu][Wrap.fields.GPUTEMP_SLOWDOWN][0].value
-                if curr_temp >= (0.95*slowdown_temp):
+                triggered, _ = evaluate("ge", curr_temp, 0.95 * slowdown_temp)
+                if triggered:
                     msg = f"GPU temperature reached very close to the slowdown limit gpu: {gpu} Curr temp: {curr_temp}, slowdown limit: {slowdown_temp}"
                     custom_fields[gpu_id]["errors"].append(msg)
                     custom_fields['error_count'] += 1
                     custom_fields['category'].add("Thermal")
                 # Clocks
                 clock_reason = gpu_values[gpu][Wrap.fields.CLOCK_REASON][0].value
-                throttle_reasons = Wrap.get_throttle_reasons(clock_reason)
-                if throttle_reasons:
+                THROTTLE_MASK = (dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_SLOWDOWN
+                                 | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_SW_THERMAL
+                                 | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_THERMAL
+                                 | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_POWER_BRAKE)
+                triggered, _ = evaluate("bitmask", clock_reason, THROTTLE_MASK)
+                if triggered:
+                    throttle_reasons = Wrap.get_throttle_reasons(clock_reason)
                     custom_fields[gpu_id]["errors"].append(throttle_reasons)
                     custom_fields['error_count'] += 1
                     custom_fields['category'].add("Clocks")
                 # Fabric errors
                 fabric_status = gpu_values[gpu][Wrap.fields.FABRIC_STATUS][0].value
-                if fabric_status == dcgm_structs.DcgmFMStatusFailure:
+                triggered, _ = evaluate("eq", fabric_status, dcgm_structs.DcgmFMStatusFailure)
+                if triggered:
                     fabric_error = gpu_values[gpu][Wrap.fields.FABRIC_ERROR][0].value
                     msg = f"Fabric Manager finished training but failed, error code: {fabric_error}"
                     custom_fields[gpu_id]["errors"].append(msg)
                     custom_fields['error_count'] += 1
                     custom_fields['category'].add("FabricManager")
-                elif fabric_status == dcgm_structs.DcgmFMStatusInProgress:
-                    fabric_error = gpu_values[gpu][Wrap.fields.FABRIC_ERROR][0].value
-                    msg = f"Fabric Manager not running, training in progress, error code: {fabric_error}"
-                    custom_fields[gpu_id]["errors"].append(msg)
-                    custom_fields['error_count'] += 1
-                    custom_fields['category'].add("FabricManager")
+                else:
+                    triggered, _ = evaluate("eq", fabric_status, dcgm_structs.DcgmFMStatusInProgress)
+                    if triggered:
+                        fabric_error = gpu_values[gpu][Wrap.fields.FABRIC_ERROR][0].value
+                        msg = f"Fabric Manager not running, training in progress, error code: {fabric_error}"
+                        custom_fields[gpu_id]["errors"].append(msg)
+                        custom_fields['error_count'] += 1
+                        custom_fields['category'].add("FabricManager")
                 # Persistence mode
                 persistence_mode = gpu_values[gpu][Wrap.fields.PERSISTENCE_MODE][0].value
-                if persistence_mode != 1:
+                triggered, _ = evaluate("ne", persistence_mode, 1)
+                if triggered:
                     msg = f"Persistence Mode not set for GPU: {gpu}, Restart nvidia-persistenced or Reboot the system."
                     custom_fields[gpu_id]["errors"].append(msg)
                     custom_fields['error_count'] += 1
                     custom_fields['category'].add("System")
                 # Row Remap failures
                 row_remap_failure = gpu_values[gpu][Wrap.fields.ROW_REMAP_FAIL][0].value
-                if row_remap_failure:
+                triggered, _ = evaluate("ne", row_remap_failure, 0)
+                if triggered:
                     msg = f"GPU {gpu}: {dcgm_errors.DCGM_FR_ROW_REMAP_FAILURE_MSG} {dcgm_errors.DCGM_FR_ROW_REMAP_FAILURE_NEXT}"
                     custom_fields[gpu_id]["errors"].append(msg)
                     custom_fields['error_count'] += 1
                     custom_fields['category'].add("Memory")
                 # DBE error
                 dbe_error = gpu_values[gpu][Wrap.fields.DBE_ERRORS][0].value
-                if dbe_error > 0:
+                triggered, _ = evaluate("gt", dbe_error, 0)
+                if triggered:
                     msg = f"{dcgm_errors.DCGM_FR_VOLATILE_DBE_DETECTED_MSG % (dbe_error, gpu)} {dcgm_errors.DCGM_FR_VOLATILE_DBE_DETECTED_NEXT}"
                     custom_fields[gpu_id]["errors"].append(msg)
                     custom_fields['error_count'] += 1

--- a/healthagent/gpu.py
+++ b/healthagent/gpu.py
@@ -229,7 +229,7 @@ class GpuHealthChecks(HealthModule):
                         if enrich:
                             details = enrich(newest.value, field_values)
                             if details:
-                                msg += " \u2014 " + "; ".join(details)
+                                msg += " -- " + "; ".join(details)
 
                         custom_fields[entity_key]["errors" if severity == "error" else "warnings"].append(msg)
                         if severity == "error":
@@ -254,14 +254,16 @@ class GpuHealthChecks(HealthModule):
                 custom_fields.setdefault(gpu_id, self._gpu_entry())
                 for entry in xids.values():
                     xid_num = entry["xid"]
+                    timestamp = entry["timestamp"]
                     if xid_num in self.XID_IGNORE:
-                        severity = "ignore"
-                    elif xid_num in self.XID_WARNING:
-                        severity = "warning"
+                        continue
+                    msg = f"[{gpu_id}] XID {xid_num} at {timestamp}"
+                    if xid_num in self.XID_WARNING:
+                        custom_fields[gpu_id]['warnings'].append(msg)
                     else:
-                        severity = "error"
+                        custom_fields[gpu_id]['errors'].append(msg)
                         custom_fields['error_count'] += 1
-                    custom_fields[gpu_id]['xid'].append({**entry, "severity": severity})
+                    custom_fields[gpu_id]['xid'].append(entry)
                 if xids:
                     custom_fields['category'].add("XID")
 
@@ -270,116 +272,6 @@ class GpuHealthChecks(HealthModule):
             log.exception(e)
             return custom_fields
 
-    # def track_fields(self):
-
-    #     """
-    #     Read field values from DCGM.
-    #     All fields (polled and event-driven) are read via GetLatest_v2.
-    #     XIDs are deduplicated and accumulated in self.xid_history for the node's lifetime.
-    #     """
-
-    #     custom_fields = {}
-    #     custom_fields['error_count'] = 0
-    #     custom_fields['category'] = set()
-    #     try:
-    #         response = self.dcgmGroup.samples.GetLatest_v2(self.field_group)
-    #         gpu_values = response.values.get(dcgm_fields.DCGM_FE_GPU, {})
-    #         for gpu in gpu_values:
-    #             gpu_id = f'GPU_{gpu}'
-    #             custom_fields.setdefault(gpu_id, self._gpu_entry())
-    #             # Handle Thermal
-    #             curr_temp = gpu_values[gpu][Wrap.fields.GPUTEMP][0].value
-    #             slowdown_temp = gpu_values[gpu][Wrap.fields.GPUTEMP_SLOWDOWN][0].value
-    #             triggered, _ = evaluate("ge", curr_temp, 0.95 * slowdown_temp)
-    #             if triggered:
-    #                 msg = f"GPU temperature reached very close to the slowdown limit gpu: {gpu} Curr temp: {curr_temp}, slowdown limit: {slowdown_temp}"
-    #                 custom_fields[gpu_id]["errors"].append(msg)
-    #                 custom_fields['error_count'] += 1
-    #                 custom_fields['category'].add("Thermal")
-    #             # Clocks
-    #             clock_reason = gpu_values[gpu][Wrap.fields.CLOCK_REASON][0].value
-    #             THROTTLE_MASK = (dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_SLOWDOWN
-    #                              | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_SW_THERMAL
-    #                              | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_THERMAL
-    #                              | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_POWER_BRAKE)
-    #             triggered, _ = evaluate("bitmask", clock_reason, THROTTLE_MASK)
-    #             if triggered:
-    #                 throttle_reasons = Wrap.get_throttle_reasons(clock_reason)
-    #                 custom_fields[gpu_id]["errors"].append(throttle_reasons)
-    #                 custom_fields['error_count'] += 1
-    #                 custom_fields['category'].add("Clocks")
-    #             # Fabric errors
-    #             fabric_status = gpu_values[gpu][Wrap.fields.FABRIC_STATUS][0].value
-    #             triggered, _ = evaluate("eq", fabric_status, dcgm_structs.DcgmFMStatusFailure)
-    #             if triggered:
-    #                 fabric_error = gpu_values[gpu][Wrap.fields.FABRIC_ERROR][0].value
-    #                 msg = f"Fabric Manager finished training but failed, error code: {fabric_error}"
-    #                 custom_fields[gpu_id]["errors"].append(msg)
-    #                 custom_fields['error_count'] += 1
-    #                 custom_fields['category'].add("FabricManager")
-    #             else:
-    #                 triggered, _ = evaluate("eq", fabric_status, dcgm_structs.DcgmFMStatusInProgress)
-    #                 if triggered:
-    #                     fabric_error = gpu_values[gpu][Wrap.fields.FABRIC_ERROR][0].value
-    #                     msg = f"Fabric Manager not running, training in progress, error code: {fabric_error}"
-    #                     custom_fields[gpu_id]["errors"].append(msg)
-    #                     custom_fields['error_count'] += 1
-    #                     custom_fields['category'].add("FabricManager")
-    #             # Persistence mode
-    #             persistence_mode = gpu_values[gpu][Wrap.fields.PERSISTENCE_MODE][0].value
-    #             triggered, _ = evaluate("ne", persistence_mode, 1)
-    #             if triggered:
-    #                 msg = f"Persistence Mode not set for GPU: {gpu}, Restart nvidia-persistenced or Reboot the system."
-    #                 custom_fields[gpu_id]["errors"].append(msg)
-    #                 custom_fields['error_count'] += 1
-    #                 custom_fields['category'].add("System")
-    #             # Row Remap failures
-    #             row_remap_failure = gpu_values[gpu][Wrap.fields.ROW_REMAP_FAIL][0].value
-    #             triggered, _ = evaluate("ne", row_remap_failure, 0)
-    #             if triggered:
-    #                 msg = f"GPU {gpu}: {dcgm_errors.DCGM_FR_ROW_REMAP_FAILURE_MSG} {dcgm_errors.DCGM_FR_ROW_REMAP_FAILURE_NEXT}"
-    #                 custom_fields[gpu_id]["errors"].append(msg)
-    #                 custom_fields['error_count'] += 1
-    #                 custom_fields['category'].add("Memory")
-    #             # DBE error
-    #             dbe_error = gpu_values[gpu][Wrap.fields.DBE_ERRORS][0].value
-    #             triggered, _ = evaluate("gt", dbe_error, 0)
-    #             if triggered:
-    #                 msg = f"{dcgm_errors.DCGM_FR_VOLATILE_DBE_DETECTED_MSG % (dbe_error, gpu)} {dcgm_errors.DCGM_FR_VOLATILE_DBE_DETECTED_NEXT}"
-    #                 custom_fields[gpu_id]["errors"].append(msg)
-    #                 custom_fields['error_count'] += 1
-    #                 custom_fields['category'].add("Memory")
-    #             # XID - read latest, deduplicate by xid number per GPU, keep earliest timestamp
-    #             xid_samples = gpu_values[gpu].get(Wrap.fields.XID_ERRORS, [])
-    #             if gpu_id not in self.xid_history:
-    #                 self.xid_history[gpu_id] = {}
-    #             for sample in xid_samples:
-    #                 if not sample.isBlank:
-    #                     xid_num = sample.value
-    #                     ts_utc = datetime.fromtimestamp(sample.ts / 1_000_000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S UTC")
-    #                     if xid_num not in self.xid_history[gpu_id] or ts_utc < self.xid_history[gpu_id][xid_num]["timestamp"]:
-    #                         self.xid_history[gpu_id][xid_num] = {"xid": xid_num, "timestamp": ts_utc}
-
-    #         # Populate report with full XID history
-    #         for gpu_id, xids in self.xid_history.items():
-    #             custom_fields.setdefault(gpu_id, self._gpu_entry())
-    #             for entry in xids.values():
-    #                 xid_num = entry["xid"]
-    #                 if xid_num in self.XID_IGNORE:
-    #                     severity = "ignore"
-    #                 elif xid_num in self.XID_WARNING:
-    #                     severity = "warning"
-    #                 else:
-    #                     severity = "error"
-    #                     custom_fields['error_count'] += 1
-    #                 custom_fields[gpu_id]['xid'].append({**entry, "severity": severity})
-    #             if xids:
-    #                 custom_fields['category'].add("XID")
-
-    #         return custom_fields
-    #     except Exception as e:
-    #         log.exception(e)
-    #         return custom_fields
 
     @healthcheck("GpuMemoryCheck", args=["gpu_id"], description="Run GPU memory allocation test. Args: gpu_id=0,1")
     @epilog
@@ -449,7 +341,6 @@ class GpuHealthChecks(HealthModule):
         custom_fields = {}
         try:
             try:
-                details = list()
                 subsystems = set()
                 report = HealthReport()
                 if not self.dcgmGroup:
@@ -498,7 +389,26 @@ class GpuHealthChecks(HealthModule):
 
                 description = f"{health_system} report {custom_fields['error_count']} errors of type {', '.join(custom_fields['category'])}"
                 report.description = description
-                report.details = '\n'.join(details)
+
+                all_errors = []
+                all_warnings = []
+                for key, val in custom_fields.items():
+                    if not isinstance(val, dict):
+                        continue
+                    for err in val.get("errors", []):
+                        all_errors.append(f"{err}")
+                    for warn in val.get("warnings", []):
+                        all_warnings.append(f"{warn}")
+
+                parts = []
+                if all_errors:
+                    parts.append("--- ERRORS ---")
+                    parts.extend(all_errors)
+                if all_warnings:
+                    parts.append("--- WARNINGS ---")
+                    parts.extend(all_warnings)
+                report.details = '\n'.join(parts)
+
                 await self.reporter.update_report(name=health_system, report=report)
                 return
 
@@ -624,10 +534,31 @@ def run_active_healthchecksv2(gpu_id: list = None, tests: str = '', params: str 
             else:
                 custom_fields[entity_id]['suppressed'].append({"msg": error_msg, "note": Wrap.DIAG_SUPPRESSED_NOTE})
     if not isHealthy:
-        #report.details = "\n".join(failures)
         report.description = "Active Diagnostic test failures"
         report.message = "GPU Epilog Errors"
         report.custom_fields = custom_fields
+
+        all_errors = []
+        all_warnings = []
+        for key, val in custom_fields.items():
+            if not isinstance(val, dict):
+                continue
+            for err in val.get("errors", []):
+                all_errors.append(f"[{key}] {err}")
+            for warn in val.get("warnings", []):
+                if isinstance(warn, dict):
+                    all_warnings.append(f"[{key}] {warn['msg']}")
+                else:
+                    all_warnings.append(f"[{key}] {warn}")
+
+        parts = []
+        if all_errors:
+            parts.append("--- ERRORS ---")
+            parts.extend(all_errors)
+        if all_warnings:
+            parts.append("--- WARNINGS ---")
+            parts.extend(all_warnings)
+        report.details = '\n'.join(parts)
 
     Wrap.disconnect(dcgmHandle, dcgmGroup)
     return report

--- a/healthagent/gpu.py
+++ b/healthagent/gpu.py
@@ -121,17 +121,40 @@ class GpuHealthChecks(HealthModule):
             log.debug("Power Limit : %s" % (Wrap.convert_value_to_string(self.gpu_config[x].mPowerLimit.val)))
             log.debug("Compute Mode: %s" % (Wrap.convert_value_to_string(self.gpu_config[x].mComputeMode)))
 
-    @healthcheck("GpuCountCheck", description="Check OS vs PCI GPU count")
-    @Scheduler.periodic(120)
+    @healthcheck("GpuCountCheck", description="Check OS vs PCI vs NVML GPU count")
+    @Scheduler.periodic(60)
     async def gpu_count_check(self):
 
         report = HealthReport()
+        custom_fields = {}
         pci_gpu_count = Wrap.count_pci_gpu_devices()
         os_gpu_count = Wrap.count_os_gpu_devices()
-        if os_gpu_count != pci_gpu_count:
+
+        # Read DCGM_FI_DEV_COUNT from the latest field collection
+        dcgm_gpu_count = None
+        devcnt_field_id = Wrap.fields.DEVCNT
+        if devcnt_field_id is not None:
+            try:
+                gpu_entities = self._field_collection.values.get(dcgm_fields.DCGM_FE_GPU, {})
+                for entity_id, field_values in gpu_entities.items():
+                    samples = field_values.get(devcnt_field_id)
+                    if samples and not samples[-1].isBlank:
+                        dcgm_gpu_count = samples[-1].value
+                        break
+            except Exception as e:
+                log.warning(f"Failed to read DCGM_FI_DEV_COUNT: {e}")
+
+        custom_fields = {"os_count": os_gpu_count, "pci_device_count": pci_gpu_count}
+        if dcgm_gpu_count is not None:
+            custom_fields["nvml_count"] = dcgm_gpu_count
+
+        unique_counts = set(custom_fields.values())
+        if len(unique_counts) > 1:
             report.status = HealthStatus.ERROR
-            report.details = f"OS shows {os_gpu_count} GPU devices, PCI Bus shows {pci_gpu_count} GPU devices"
+            detail_parts = [f"{source} shows {count}" for source, count in custom_fields.items()]
+            report.details = "GPU count mismatch: " + ", ".join(detail_parts)
             report.description = "GPU Count Mismatch"
+            report.custom_fields = custom_fields
         await self.reporter.update_report(name=self.gpu_count_check.report_name, report=report)
 
     async def create(self):

--- a/healthagent/gpu.py
+++ b/healthagent/gpu.py
@@ -3,7 +3,7 @@ import sys
 import logging
 import os
 import shutil
-from datetime import datetime
+from datetime import datetime, timezone
 from healthagent import epilog,status,healthcheck
 from healthagent.scheduler import Scheduler
 from healthagent.healthmodule import HealthModule
@@ -46,6 +46,7 @@ class GpuHealthChecks(HealthModule):
         self.dcgmHandle = None
         self.watch_fields = []
         self.gpu_config = []
+        self.xid_history = {}
         if self.test_mode:
             log.info("Running GPU tests in DCGM_TEST_MODE")
         self.dcgmGroup, self.dcgmHandle = Wrap.connect(grp_name="healthagent_group", test_mode=self.test_mode)
@@ -62,7 +63,7 @@ class GpuHealthChecks(HealthModule):
         """
 
         # TODO: These limits will come from a configuration file eventually.
-        policy = Wrap.set_policy(mpe=8)
+        policy = Wrap.set_policy()
         self.dcgmGroup.policy.Set(policy)
         self.c_callback = create_c_callback(self.handle_policy_violation, asyncio.get_running_loop())
         self.dcgmGroup.policy.Register(policy.condition, self.c_callback, None)
@@ -72,16 +73,11 @@ class GpuHealthChecks(HealthModule):
         """
         Setup field watches and health watches.
         """
-        # TODO: Add more fields to watch fields in addition to policy fields
-        # but for now just add policy fields.
         self.watch_fields = Wrap.get_fields()
-        self.field_group = DcgmFieldGroup.DcgmFieldGroup(self.dcgmHandle, name="ccfield_group_instant", fieldIds=self.watch_fields)
+        self.field_group = DcgmFieldGroup.DcgmFieldGroup(self.dcgmHandle, name="ccfield_group", fieldIds=self.watch_fields)
         # UpdateFreq is in microseconds. So we are updating every 1 second.
-        # MaxKeepAge:  is how long samples are stored in memory, in seconds. 0 means maxkeepsamples enforces the bounds.
-        # maxkeepsamples: how many samples are stored in DCGM Cache. For this particular field group, we only ever read the latest value. See function track_fields.
-        # Storing last 10 samples (or last 10 seconds of data) is more than enough and effectively  bounds the memory.
-        # If we need historical trending for a field group we will create a new field group with appropriate retention policies.
-        self.dcgmGroup.samples.WatchFields(fieldGroup=self.field_group, updateFreq=1000000, maxKeepAge=0, maxKeepSamples=10)
+        # maxKeepSamples=60 bounds memory. We read the latest value each cycle.
+        self.dcgmGroup.samples.WatchFields(fieldGroup=self.field_group, updateFreq=1000000, maxKeepAge=0, maxKeepSamples=60)
         ## Add the health watches
         self.dcgmGroup.health.Set(Wrap.get_health_mask())
 
@@ -118,135 +114,133 @@ class GpuHealthChecks(HealthModule):
         Scheduler.add_task(self.gpu_count_check)
         Scheduler.add_task(self.run_background_healthchecks)
 
-    @healthcheck("GpuPolicyCheck", description="GPU policy violation checks")
     async def handle_policy_violation(self, callbackresp):
 
-        health_system = self.handle_policy_violation.report_name
-        report = self.reporter.get_report(health_system) or HealthReport()
         condition = callbackresp.condition
-        gpuid = callbackresp.gpuId
-        harmless_xid = [ 43, 63 ]
         try:
             condition_str = Wrap.dcgm_condition_to_string(condition=condition)
+            if condition == dcgm_structs.DCGM_POLICY_COND_XID:
+                gpuid = callbackresp.gpuId
+                xid_received = callbackresp.val.xid.errnum
+                unix_ts = callbackresp.val.xid.timestamp
+                timestamp = datetime.fromtimestamp(unix_ts / 1_000_000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S UTC")
+                log.critical("XID detected: %d  on gpu: %d" % (xid_received, gpuid))
+                gpu_key = f'GPU_{gpuid}'
+                if gpu_key not in self.xid_history:
+                    self.xid_history[gpu_key] = {}
+                if xid_received not in self.xid_history[gpu_key] or timestamp < self.xid_history[gpu_key][xid_received]["timestamp"]:
+                    self.xid_history[gpu_key][xid_received] = {"xid": xid_received, "timestamp": timestamp}
         except ValueError as e:
             log.exception(e)
             return
 
-        log.critical("Violation detected: %s  on gpu: %d" % (condition_str, gpuid))
+    # TODO: Adding all config file attributes as class objects for now.
+    XID_WARNING = [43, 63, 13, 31, 66, 94, 154]
+    XID_IGNORE = []
+    XID_ERROR = []
 
-        if condition_str not in report.custom_fields:
-            report.custom_fields[condition_str] = {}
-            # violation data is a 2D dict containing violation results indexed by condition and gpu id. vd[condition][gpuid]
-            vd = {}
-        else:
-            vd = report.custom_fields[condition_str]
-
-        #vd['timestamp'] = condition.val.timestamp
-        if gpuid not in vd:
-            vd[gpuid] = {}
-
-        info = vd[gpuid]
-        if condition == dcgm_structs.DCGM_POLICY_COND_DBE:
-            if 'location' not in info:
-                info['location'] = set()
-            info['location'].add(next(key for key, value in dcgm_structs.c_dcgmPolicyConditionDbe_t.LOCATIONS.items() if value == callbackresp.val.dbe.location))
-            info['numerrors'] = callbackresp.val.dbe.numerrors
-            info['details'] = f"Double-Bit ECC errors({info['numerrors']}) found at location: {info['location']} on GPU: {gpuid}"
-            report.escalate(HealthStatus.ERROR)
-        elif condition == dcgm_structs.DCGM_POLICY_COND_PCI:
-            info['replay_count'] = callbackresp.val.pci.counter
-            info['details'] = f"PCI replay count({info['replay_count']}) on GPU: {gpuid}"
-            report.escalate(HealthStatus.ERROR)
-        elif condition == dcgm_structs.DCGM_POLICY_COND_NVLINK:
-            info['error_count'] = callbackresp.val.nvlink.counter
-            if 'field_id' not in info:
-                info['field_id'] = set()
-            info['field_id'].add(callbackresp.val.nvlink.fieldId)
-            info['details'] = f"Nvlink violation on GPU: {gpuid}"
-            report.escalate(HealthStatus.ERROR)
-        elif condition == dcgm_structs.DCGM_POLICY_COND_XID:
-            if 'xid_error' not in info:
-                info['xid_error'] = set()
-            info['xid_error'].add(callbackresp.val.xid.errnum)
-            info['details'] = f"XID errors found: XID {info['xid_error']} on GPU {gpuid}"
-            # Harmless XIDs are warnings; others are errors
-            if info['xid_error'].issubset(set(harmless_xid)):
-                report.escalate(HealthStatus.WARNING)
-            else:
-                report.escalate(HealthStatus.ERROR)
-        # elif condition == dcgm_structs.DCGM_POLICY_COND_THERMAL:
-        #     report.escalate(HealthStatus.WARNING)
-        #     info['temperature'] = callbackresp.val.thermal.thermalViolation
-        #     info['details'] = f"Thermal violation detected: Temperature reached {info['temperature']} Celsius GPU: {gpuid}"
-        # elif condition == dcgm_structs.DCGM_POLICY_COND_POWER:
-        #     report.escalate(HealthStatus.WARNING)
-        #     info['power'] = callbackresp.val.power.powerViolation
-        #     info['details'] = f"Power violation detected: Power draw {info['power']} Watts GPU: {gpuid}"
-        elif condition == dcgm_structs.DCGM_POLICY_COND_MAX_PAGES_RETIRED:
-            info['sbepage_count'] = callbackresp.val.mpr.sbepages
-            info['dbepage_count'] = callbackresp.val.mpr.dbepages
-            info['details'] = f"Max retired pages violation: SBE retired pages: {info['sbepage_count']}, DBE retired pages {info['dbepage_count']} GPU: {gpuid}"
-            report.escalate(HealthStatus.ERROR)
-
-        vd[gpuid] = info
-        report.custom_fields[condition_str] = vd
-        report.description = "GPU Policy Violations detected"
-        if not report.details:
-            report.details = info['details']
-        else:
-            # regenerate
-            report.details = ""
-            for condition in report.custom_fields:
-                for gpu in report.custom_fields[condition]:
-                    report.details += f"\n{report.custom_fields[condition][gpu]['details']}"
-        await self.reporter.update_report(name=health_system, report=report)
-        return
-
+    @staticmethod
+    def _gpu_entry():
+        return {"errors": [], "warnings": [], "xid": []}
 
     def track_fields(self):
 
         """
         Read field values from DCGM.
+        All fields (polled and event-driven) are read via GetLatest_v2.
+        XIDs are deduplicated and accumulated in self.xid_history for the node's lifetime.
         """
 
-        errors = []
-        category = []
+        custom_fields = {}
+        custom_fields['error_count'] = 0
+        custom_fields['category'] = set()
         try:
-            response = self.dcgmGroup.samples.GetLatest(self.field_group)
-            for gpu in response.values:
-
-                curr_temp = response.values[gpu][Wrap.fields.GPUTEMP][0].value
-                slowdown_temp = response.values[gpu][Wrap.fields.GPUTEMP_SLOWDOWN][0].value
+            response = self.dcgmGroup.samples.GetLatest_v2(self.field_group)
+            gpu_values = response.values.get(dcgm_fields.DCGM_FE_GPU, {})
+            for gpu in gpu_values:
+                gpu_id = f'GPU_{gpu}'
+                custom_fields.setdefault(gpu_id, self._gpu_entry())
+                # Handle Thermal
+                curr_temp = gpu_values[gpu][Wrap.fields.GPUTEMP][0].value
+                slowdown_temp = gpu_values[gpu][Wrap.fields.GPUTEMP_SLOWDOWN][0].value
                 if curr_temp >= (0.95*slowdown_temp):
                     msg = f"GPU temperature reached very close to the slowdown limit gpu: {gpu} Curr temp: {curr_temp}, slowdown limit: {slowdown_temp}"
-                    errors.append(msg)
-                    category.append("Thermal")
-
-                clock_reason = response.values[gpu][Wrap.fields.CLOCK_REASON][0].value
+                    custom_fields[gpu_id]["errors"].append(msg)
+                    custom_fields['error_count'] += 1
+                    custom_fields['category'].add("Thermal")
+                # Clocks
+                clock_reason = gpu_values[gpu][Wrap.fields.CLOCK_REASON][0].value
                 throttle_reasons = Wrap.get_throttle_reasons(clock_reason)
                 if throttle_reasons:
-                    errors.extend(throttle_reasons)
-                    category.append("Clocks")
-                fabric_status = response.values[gpu][Wrap.fields.FABRIC_STATUS][0].value
+                    custom_fields[gpu_id]["errors"].append(throttle_reasons)
+                    custom_fields['error_count'] += 1
+                    custom_fields['category'].add("Clocks")
+                # Fabric errors
+                fabric_status = gpu_values[gpu][Wrap.fields.FABRIC_STATUS][0].value
                 if fabric_status == dcgm_structs.DcgmFMStatusFailure:
-                    fabric_error = response.values[gpu][Wrap.fields.FABRIC_ERROR][0].value
+                    fabric_error = gpu_values[gpu][Wrap.fields.FABRIC_ERROR][0].value
                     msg = f"Fabric Manager finished training but failed, error code: {fabric_error}"
-                    errors.append(msg)
-                    category.append("FabricManager")
+                    custom_fields[gpu_id]["errors"].append(msg)
+                    custom_fields['error_count'] += 1
+                    custom_fields['category'].add("FabricManager")
                 elif fabric_status == dcgm_structs.DcgmFMStatusInProgress:
-                    fabric_error = response.values[gpu][Wrap.fields.FABRIC_ERROR][0].value
+                    fabric_error = gpu_values[gpu][Wrap.fields.FABRIC_ERROR][0].value
                     msg = f"Fabric Manager not running, training in progress, error code: {fabric_error}"
-                    errors.append(msg)
-                    category.append("FabricManager")
-                persistence_mode = response.values[gpu][Wrap.fields.PERSISTENCE_MODE][0].value
+                    custom_fields[gpu_id]["errors"].append(msg)
+                    custom_fields['error_count'] += 1
+                    custom_fields['category'].add("FabricManager")
+                # Persistence mode
+                persistence_mode = gpu_values[gpu][Wrap.fields.PERSISTENCE_MODE][0].value
                 if persistence_mode != 1:
                     msg = f"Persistence Mode not set for GPU: {gpu}, Restart nvidia-persistenced or Reboot the system."
-                    errors.append(msg)
-                    category.append("System")
+                    custom_fields[gpu_id]["errors"].append(msg)
+                    custom_fields['error_count'] += 1
+                    custom_fields['category'].add("System")
+                # Row Remap failures
+                row_remap_failure = gpu_values[gpu][Wrap.fields.ROW_REMAP_FAIL][0].value
+                if row_remap_failure:
+                    msg = f"GPU {gpu}: {dcgm_errors.DCGM_FR_ROW_REMAP_FAILURE_MSG} {dcgm_errors.DCGM_FR_ROW_REMAP_FAILURE_NEXT}"
+                    custom_fields[gpu_id]["errors"].append(msg)
+                    custom_fields['error_count'] += 1
+                    custom_fields['category'].add("Memory")
+                # DBE error
+                dbe_error = gpu_values[gpu][Wrap.fields.DBE_ERRORS][0].value
+                if dbe_error > 0:
+                    msg = f"{dcgm_errors.DCGM_FR_VOLATILE_DBE_DETECTED_MSG % (dbe_error, gpu)} {dcgm_errors.DCGM_FR_VOLATILE_DBE_DETECTED_NEXT}"
+                    custom_fields[gpu_id]["errors"].append(msg)
+                    custom_fields['error_count'] += 1
+                    custom_fields['category'].add("Memory")
+                # XID - read latest, deduplicate by xid number per GPU, keep earliest timestamp
+                xid_samples = gpu_values[gpu].get(Wrap.fields.XID_ERRORS, [])
+                if gpu_id not in self.xid_history:
+                    self.xid_history[gpu_id] = {}
+                for sample in xid_samples:
+                    if not sample.isBlank:
+                        xid_num = sample.value
+                        ts_utc = datetime.fromtimestamp(sample.ts / 1_000_000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S UTC")
+                        if xid_num not in self.xid_history[gpu_id] or ts_utc < self.xid_history[gpu_id][xid_num]["timestamp"]:
+                            self.xid_history[gpu_id][xid_num] = {"xid": xid_num, "timestamp": ts_utc}
 
-            return errors, category
+            # Populate report with full XID history
+            for gpu_id, xids in self.xid_history.items():
+                custom_fields.setdefault(gpu_id, self._gpu_entry())
+                for entry in xids.values():
+                    xid_num = entry["xid"]
+                    if xid_num in self.XID_IGNORE:
+                        severity = "ignore"
+                    elif xid_num in self.XID_WARNING:
+                        severity = "warning"
+                    else:
+                        severity = "error"
+                        custom_fields['error_count'] += 1
+                    custom_fields[gpu_id]['xid'].append({**entry, "severity": severity})
+                if xids:
+                    custom_fields['category'].add("XID")
+
+            return custom_fields
         except Exception as e:
             log.exception(e)
+            return custom_fields
 
     @healthcheck("GpuMemoryCheck", args=["gpu_id"], description="Run GPU memory allocation test. Args: gpu_id=0,1")
     @epilog
@@ -294,6 +288,7 @@ class GpuHealthChecks(HealthModule):
         response[health_system] = report.view()
         return response
 
+
     @healthcheck("GpuHealthCheck", description="Periodic GPU health monitoring")
     @Scheduler.periodic(60)
     async def run_background_healthchecks(self):
@@ -314,37 +309,47 @@ class GpuHealthChecks(HealthModule):
                 group_health = self.dcgmGroup.health.Check()
                 incident_count = group_health.incidentCount
 
-                field_errors, category = self.track_fields()
-                if len(field_errors) > 0:
+                custom_fields = self.track_fields()
+                if custom_fields.get('error_count', 0) > 0:
                     report.escalate(HealthStatus.ERROR)
-                if report.status == HealthStatus.OK and incident_count == 0:
+
+                for index in range (0, incident_count):
+                    entity_id = group_health.incidents[index].entityInfo.entityId
+                    if entity_id == dcgm_fields.DCGM_FE_GPU:
+                        entity = f"GPU_{entity_id}"
+                        custom_fields.setdefault(entity, self._gpu_entry())
+                    else:
+                        entity = "overall"
+                        custom_fields.setdefault(entity, {"errors": [], "warnings": []})
+                    system = Wrap.convert_system_enum_to_system_name(group_health.incidents[index].system)
+                    error_code = group_health.incidents[index].error.code
+                    if error_code in Wrap.HEALTH_WARNINGS:
+                        custom_fields[entity]['warnings'].append(group_health.incidents[index].error.msg)
+                        report.escalate(HealthStatus.WARNING)
+                        subsystems.add(system)
+                    elif error_code in Wrap.HEALTH_ERRORS:
+                        report.escalate(HealthStatus.ERROR)
+                        custom_fields[entity]['errors'].append(group_health.incidents[index].error.msg)
+                        subsystems.add(system)
+                        custom_fields['error_count'] += 1
+                    else:
+                        #ignore
+                        continue
+
+                #details.extend(field_errors)
+                custom_fields['category'].update(subsystems)
+                report.custom_fields = {
+                    k: v for k, v in custom_fields.items()
+                    if not isinstance(v, dict) or any(v.values())
+                }
+
+                if custom_fields['error_count'] == 0:
                     await self.reporter.update_report(name=health_system, report=report)
                     return
 
-                for index in range (0, incident_count):
-                    gpu_id = group_health.incidents[index].entityInfo.entityId
-                    system = Wrap.convert_system_enum_to_system_name(group_health.incidents[index].system)
-                    error_code = group_health.incidents[index].error.code
-                    if error_code == dcgm_errors.DCGM_FR_NVLINK_EFFECTIVE_BER_THRESHOLD:
-                        report.escalate(HealthStatus.WARNING)
-                    else:
-                        incident_status = Wrap.convert_health_to_status(group_health.incidents[index].health)
-                        if incident_status == HealthStatus.NA:
-                            log.error(f"Invalid health status receieved {system}, {error_code}")
-                        elif incident_status != HealthStatus.NA:
-                            report.escalate(incident_status)
-                    subsystems.add(system)
-                    details.append(group_health.incidents[index].error.msg)
-
-                details.extend(field_errors)
-                subsystems.update(category)
-                incident_count += len(field_errors)
-                description = f"{health_system} report {report.status.value} count={incident_count} subsystem={', '.join(subsystems)}"
-                custom_fields['categories'] = subsystems
-                custom_fields['error_count'] = incident_count
+                description = f"{health_system} report {custom_fields['error_count']} errors of type {', '.join(custom_fields['category'])}"
                 report.description = description
                 report.details = '\n'.join(details)
-                report.custom_fields = custom_fields
                 await self.reporter.update_report(name=health_system, report=report)
                 return
 
@@ -382,6 +387,9 @@ class GpuHealthChecks(HealthModule):
             ## disconnect from the hostengine by deleting the DcgmHandle object
             del(self.dcgmHandle)
 
+def _diag_entry():
+    return {"errors": [], "warnings": [], "suppressed": []}
+
 @Scheduler.pool
 def run_active_healthchecksv2():
 
@@ -394,9 +402,8 @@ def run_active_healthchecksv2():
     isHealthy = True
     report = HealthReport()
     custom_fields = {}
-
-    failures = list()
-    info_msgs = list()
+    custom_fields['error_count'] = 0
+    response = None
     try:
         #TODO: Find a better way to get this directory later.
         log_dir = "/opt/healthagent"
@@ -434,46 +441,41 @@ def run_active_healthchecksv2():
         response = dd.Execute(handle=dcgmHandle.handle)
 
     except Wrap.DcgmConnectionFail as e:
-        failures.append(str(e))
         report = HealthReport(status=HealthStatus.WARNING, description="Active Tests not performed",
                               details=f"Active diagnostics not performed.\n {e}")
         return report
     except dcgm_structs.DCGMError as e:
-        failures.append(str(e))
+        isHealthy = False
+        custom_fields['error_count'] += 1
+        custom_fields.setdefault('overall', _diag_entry())
+        custom_fields['overall']['errors'].append(str(e))
 
-    test_types = set()
-    if response.numErrors > 0:
+    if response and response.numErrors > 0:
         isHealthy = False
         for errIdx in range(response.numErrors):
             curErr = response.errors[errIdx]
             error_msg = curErr.msg
-            if curErr.testId == dcgm_structs.DCGM_DIAG_RESPONSE_SYSTEM_ERROR:
-                testName = "System"
-                failures.append(f"System Error: {error_msg}")
-                test_types.add(testName)
-            elif curErr.entity.entityGroupId == dcgm_fields.DCGM_FE_GPU:
-                testName = response.tests[curErr.testId].name
-                gpuId = curErr.entity.entityId
-                failures.append(f"GPU: {gpuId}, Test name: {testName}, Error: {error_msg}")
-                test_types.add(testName)
+            error_code = curErr.code
+            if curErr.entity.entityGroupId == dcgm_fields.DCGM_FE_GPU:
+                entity_id = f"GPU_{curErr.entity.entityId}"
             else:
-                failures.append(f"Error: {error_msg}")
-    if response.numInfo > 0:
-        for i in range(response.numInfo):
-            info = response.info[i]
-            testName = response.tests[info.testId].name
-            info_msgs.append(f"Test: {testName}, Info: {info.msg}")
-
+                entity_id = "overall"
+            custom_fields.setdefault(entity_id, _diag_entry())
+            if error_code in Wrap.DIAG_ERRORS:
+                custom_fields[entity_id]['errors'].append(error_msg)
+                custom_fields['error_count'] += 1
+                report.escalate(HealthStatus.ERROR)
+            elif error_code in Wrap.DIAG_WARNINGS:
+                note = Wrap.DIAG_WARNINGS[error_code]
+                custom_fields[entity_id]['warnings'].append({"msg": error_msg, "note": note})
+                report.escalate(HealthStatus.WARNING)
+            elif error_code in Wrap.DIAG_IGNORE:
+                continue
+            else:
+                custom_fields[entity_id]['suppressed'].append({"msg": error_msg, "note": Wrap.DIAG_SUPPRESSED_NOTE})
     if not isHealthy:
-        custom_fields['failures'] = test_types
-        custom_fields['error_count'] = len(failures)
-        custom_fields['info'] = info_msgs
-        report.status = HealthStatus.ERROR
-        report.details = "\n".join(failures)
-        if test_types:
-            report.description = f"DCGM Epilog failures in {', '.join(test_types)}"
-        else:
-            report.description = "DCGM Epilog failures detected"
+        #report.details = "\n".join(failures)
+        report.description = "Active Diagnostic test failures"
         report.message = "GPU Epilog Errors"
         report.custom_fields = custom_fields
 

--- a/healthagent/gpu.py
+++ b/healthagent/gpu.py
@@ -9,6 +9,7 @@ from healthagent.scheduler import Scheduler
 from healthagent.healthmodule import HealthModule
 from healthagent.config import GpuConfig
 from healthagent.reporter import Reporter, HealthReport,HealthStatus
+from healthagent.util import evaluate
 from healthagent.bindings import *
 
 log = logging.getLogger('healthagent')
@@ -76,8 +77,8 @@ class GpuHealthChecks(HealthModule):
         self.watch_fields = Wrap.get_fields()
         self.field_group = DcgmFieldGroup.DcgmFieldGroup(self.dcgmHandle, name="ccfield_group", fieldIds=self.watch_fields)
         # UpdateFreq is in microseconds. So we are updating every 1 second.
-        # maxKeepSamples=60 bounds memory. We read the latest value each cycle.
-        self.dcgmGroup.samples.WatchFields(fieldGroup=self.field_group, updateFreq=1000000, maxKeepAge=0, maxKeepSamples=60)
+        # maxKeepSamples=300 bounds memory. We read the latest value each cycle.
+        self.dcgmGroup.samples.WatchFields(fieldGroup=self.field_group, updateFreq=1000000, maxKeepAge=0, maxKeepSamples=300)
         ## Add the health watches
         self.dcgmGroup.health.Set(Wrap.get_health_mask())
 
@@ -143,6 +144,85 @@ class GpuHealthChecks(HealthModule):
     def _gpu_entry():
         return {"errors": [], "warnings": [], "xid": []}
 
+    def track_fieldsv2(self):
+        """
+        Generic field watch evaluation driven by Wrap.default_field_watches.
+        Reads DCGM field values and evaluates each watch against its thresholds.
+        XIDs are handled separately — not part of field watches.
+        """
+        custom_fields = {'error_count': 0, 'category': set()}
+        try:
+            response = self.dcgmGroup.samples.GetLatest_v2(self.field_group)
+            gpu_values = response.values.get(dcgm_fields.DCGM_FE_GPU, {})
+            for gpu in gpu_values:
+                gpu_id = f'GPU_{gpu}'
+                custom_fields.setdefault(gpu_id, self._gpu_entry())
+
+                for watch in Wrap.default_field_watches:
+                    samples = gpu_values[gpu].get(watch["field_id"])
+                    if not samples or samples[0].isBlank:
+                        continue
+
+                    newest, oldest = samples[0], samples[-1]
+                    severity = None
+                    threshold_used = None
+                    evaluated = None
+                    for level in ("error", "warning"):
+                        thresh = watch.get(level)
+                        if thresh is None:
+                            continue
+                        triggered, evaluated = evaluate(
+                            watch["eval"], newest.value, thresh,
+                            prev_value=oldest.value,
+                            prev_time=oldest.ts,
+                            current_time=newest.ts,
+                            window=watch.get("window", 60),
+                        )
+                        if triggered:
+                            severity = level
+                            threshold_used = thresh
+                            break
+
+                    if severity is None:
+                        continue
+
+                    msg = watch["message"].format(gpu=gpu, value=evaluated, threshold=threshold_used)
+                    custom_fields[gpu_id]["errors" if severity == "error" else "warnings"].append(msg)
+                    if severity == "error":
+                        custom_fields['error_count'] += 1
+                    custom_fields['category'].add(watch["category"])
+
+                # XID - read latest, deduplicate by xid number per GPU, keep earliest timestamp
+                xid_samples = gpu_values[gpu].get(Wrap.fields.XID_ERRORS, [])
+                if gpu_id not in self.xid_history:
+                    self.xid_history[gpu_id] = {}
+                for sample in xid_samples:
+                    if not sample.isBlank:
+                        xid_num = sample.value
+                        ts_utc = datetime.fromtimestamp(sample.ts / 1_000_000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S UTC")
+                        if xid_num not in self.xid_history[gpu_id] or ts_utc < self.xid_history[gpu_id][xid_num]["timestamp"]:
+                            self.xid_history[gpu_id][xid_num] = {"xid": xid_num, "timestamp": ts_utc}
+
+            # Populate report with full XID history
+            for gpu_id, xids in self.xid_history.items():
+                custom_fields.setdefault(gpu_id, self._gpu_entry())
+                for entry in xids.values():
+                    xid_num = entry["xid"]
+                    if xid_num in self.XID_IGNORE:
+                        severity = "ignore"
+                    elif xid_num in self.XID_WARNING:
+                        severity = "warning"
+                    else:
+                        severity = "error"
+                        custom_fields['error_count'] += 1
+                    custom_fields[gpu_id]['xid'].append({**entry, "severity": severity})
+                if xids:
+                    custom_fields['category'].add("XID")
+
+            return custom_fields
+        except Exception as e:
+            log.exception(e)
+            return custom_fields
     def track_fields(self):
 
         """
@@ -163,49 +243,61 @@ class GpuHealthChecks(HealthModule):
                 # Handle Thermal
                 curr_temp = gpu_values[gpu][Wrap.fields.GPUTEMP][0].value
                 slowdown_temp = gpu_values[gpu][Wrap.fields.GPUTEMP_SLOWDOWN][0].value
-                if curr_temp >= (0.95*slowdown_temp):
+                triggered, _ = evaluate("ge", curr_temp, 0.95 * slowdown_temp)
+                if triggered:
                     msg = f"GPU temperature reached very close to the slowdown limit gpu: {gpu} Curr temp: {curr_temp}, slowdown limit: {slowdown_temp}"
                     custom_fields[gpu_id]["errors"].append(msg)
                     custom_fields['error_count'] += 1
                     custom_fields['category'].add("Thermal")
                 # Clocks
                 clock_reason = gpu_values[gpu][Wrap.fields.CLOCK_REASON][0].value
-                throttle_reasons = Wrap.get_throttle_reasons(clock_reason)
-                if throttle_reasons:
+                THROTTLE_MASK = (dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_SLOWDOWN
+                                 | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_SW_THERMAL
+                                 | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_THERMAL
+                                 | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_POWER_BRAKE)
+                triggered, _ = evaluate("bitmask", clock_reason, THROTTLE_MASK)
+                if triggered:
+                    throttle_reasons = Wrap.get_throttle_reasons(clock_reason)
                     custom_fields[gpu_id]["errors"].append(throttle_reasons)
                     custom_fields['error_count'] += 1
                     custom_fields['category'].add("Clocks")
                 # Fabric errors
                 fabric_status = gpu_values[gpu][Wrap.fields.FABRIC_STATUS][0].value
-                if fabric_status == dcgm_structs.DcgmFMStatusFailure:
+                triggered, _ = evaluate("eq", fabric_status, dcgm_structs.DcgmFMStatusFailure)
+                if triggered:
                     fabric_error = gpu_values[gpu][Wrap.fields.FABRIC_ERROR][0].value
                     msg = f"Fabric Manager finished training but failed, error code: {fabric_error}"
                     custom_fields[gpu_id]["errors"].append(msg)
                     custom_fields['error_count'] += 1
                     custom_fields['category'].add("FabricManager")
-                elif fabric_status == dcgm_structs.DcgmFMStatusInProgress:
-                    fabric_error = gpu_values[gpu][Wrap.fields.FABRIC_ERROR][0].value
-                    msg = f"Fabric Manager not running, training in progress, error code: {fabric_error}"
-                    custom_fields[gpu_id]["errors"].append(msg)
-                    custom_fields['error_count'] += 1
-                    custom_fields['category'].add("FabricManager")
+                else:
+                    triggered, _ = evaluate("eq", fabric_status, dcgm_structs.DcgmFMStatusInProgress)
+                    if triggered:
+                        fabric_error = gpu_values[gpu][Wrap.fields.FABRIC_ERROR][0].value
+                        msg = f"Fabric Manager not running, training in progress, error code: {fabric_error}"
+                        custom_fields[gpu_id]["errors"].append(msg)
+                        custom_fields['error_count'] += 1
+                        custom_fields['category'].add("FabricManager")
                 # Persistence mode
                 persistence_mode = gpu_values[gpu][Wrap.fields.PERSISTENCE_MODE][0].value
-                if persistence_mode != 1:
+                triggered, _ = evaluate("ne", persistence_mode, 1)
+                if triggered:
                     msg = f"Persistence Mode not set for GPU: {gpu}, Restart nvidia-persistenced or Reboot the system."
                     custom_fields[gpu_id]["errors"].append(msg)
                     custom_fields['error_count'] += 1
                     custom_fields['category'].add("System")
                 # Row Remap failures
                 row_remap_failure = gpu_values[gpu][Wrap.fields.ROW_REMAP_FAIL][0].value
-                if row_remap_failure:
+                triggered, _ = evaluate("ne", row_remap_failure, 0)
+                if triggered:
                     msg = f"GPU {gpu}: {dcgm_errors.DCGM_FR_ROW_REMAP_FAILURE_MSG} {dcgm_errors.DCGM_FR_ROW_REMAP_FAILURE_NEXT}"
                     custom_fields[gpu_id]["errors"].append(msg)
                     custom_fields['error_count'] += 1
                     custom_fields['category'].add("Memory")
                 # DBE error
                 dbe_error = gpu_values[gpu][Wrap.fields.DBE_ERRORS][0].value
-                if dbe_error > 0:
+                triggered, _ = evaluate("gt", dbe_error, 0)
+                if triggered:
                     msg = f"{dcgm_errors.DCGM_FR_VOLATILE_DBE_DETECTED_MSG % (dbe_error, gpu)} {dcgm_errors.DCGM_FR_VOLATILE_DBE_DETECTED_NEXT}"
                     custom_fields[gpu_id]["errors"].append(msg)
                     custom_fields['error_count'] += 1

--- a/healthagent/gpu.py
+++ b/healthagent/gpu.py
@@ -230,7 +230,7 @@ class GpuHealthChecks(HealthModule):
                         if enrich:
                             details = enrich(newest.value, field_values)
                             if details:
-                                msg += " \u2014 " + "; ".join(details)
+                                msg += " -- " + "; ".join(details)
 
                         custom_fields[entity_key]["errors" if severity == "error" else "warnings"].append(msg)
                         if severity == "error":
@@ -255,14 +255,16 @@ class GpuHealthChecks(HealthModule):
                 custom_fields.setdefault(gpu_id, self._gpu_entry())
                 for entry in xids.values():
                     xid_num = entry["xid"]
+                    timestamp = entry["timestamp"]
                     if xid_num in self.XID_IGNORE:
-                        severity = "ignore"
-                    elif xid_num in self.XID_WARNING:
-                        severity = "warning"
+                        continue
+                    msg = f"[{gpu_id}] XID {xid_num} at {timestamp}"
+                    if xid_num in self.XID_WARNING:
+                        custom_fields[gpu_id]['warnings'].append(msg)
                     else:
-                        severity = "error"
+                        custom_fields[gpu_id]['errors'].append(msg)
                         custom_fields['error_count'] += 1
-                    custom_fields[gpu_id]['xid'].append({**entry, "severity": severity})
+                    custom_fields[gpu_id]['xid'].append(entry)
                 if xids:
                     custom_fields['category'].add("XID")
 
@@ -271,116 +273,6 @@ class GpuHealthChecks(HealthModule):
             log.exception(e)
             return custom_fields
 
-    # def track_fields(self):
-
-    #     """
-    #     Read field values from DCGM.
-    #     All fields (polled and event-driven) are read via GetLatest_v2.
-    #     XIDs are deduplicated and accumulated in self.xid_history for the node's lifetime.
-    #     """
-
-    #     custom_fields = {}
-    #     custom_fields['error_count'] = 0
-    #     custom_fields['category'] = set()
-    #     try:
-    #         response = self.dcgmGroup.samples.GetLatest_v2(self.field_group)
-    #         gpu_values = response.values.get(dcgm_fields.DCGM_FE_GPU, {})
-    #         for gpu in gpu_values:
-    #             gpu_id = f'GPU_{gpu}'
-    #             custom_fields.setdefault(gpu_id, self._gpu_entry())
-    #             # Handle Thermal
-    #             curr_temp = gpu_values[gpu][Wrap.fields.GPUTEMP][0].value
-    #             slowdown_temp = gpu_values[gpu][Wrap.fields.GPUTEMP_SLOWDOWN][0].value
-    #             triggered, _ = evaluate("ge", curr_temp, 0.95 * slowdown_temp)
-    #             if triggered:
-    #                 msg = f"GPU temperature reached very close to the slowdown limit gpu: {gpu} Curr temp: {curr_temp}, slowdown limit: {slowdown_temp}"
-    #                 custom_fields[gpu_id]["errors"].append(msg)
-    #                 custom_fields['error_count'] += 1
-    #                 custom_fields['category'].add("Thermal")
-    #             # Clocks
-    #             clock_reason = gpu_values[gpu][Wrap.fields.CLOCK_REASON][0].value
-    #             THROTTLE_MASK = (dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_SLOWDOWN
-    #                              | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_SW_THERMAL
-    #                              | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_THERMAL
-    #                              | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_POWER_BRAKE)
-    #             triggered, _ = evaluate("bitmask", clock_reason, THROTTLE_MASK)
-    #             if triggered:
-    #                 throttle_reasons = Wrap.get_throttle_reasons(clock_reason)
-    #                 custom_fields[gpu_id]["errors"].append(throttle_reasons)
-    #                 custom_fields['error_count'] += 1
-    #                 custom_fields['category'].add("Clocks")
-    #             # Fabric errors
-    #             fabric_status = gpu_values[gpu][Wrap.fields.FABRIC_STATUS][0].value
-    #             triggered, _ = evaluate("eq", fabric_status, dcgm_structs.DcgmFMStatusFailure)
-    #             if triggered:
-    #                 fabric_error = gpu_values[gpu][Wrap.fields.FABRIC_ERROR][0].value
-    #                 msg = f"Fabric Manager finished training but failed, error code: {fabric_error}"
-    #                 custom_fields[gpu_id]["errors"].append(msg)
-    #                 custom_fields['error_count'] += 1
-    #                 custom_fields['category'].add("FabricManager")
-    #             else:
-    #                 triggered, _ = evaluate("eq", fabric_status, dcgm_structs.DcgmFMStatusInProgress)
-    #                 if triggered:
-    #                     fabric_error = gpu_values[gpu][Wrap.fields.FABRIC_ERROR][0].value
-    #                     msg = f"Fabric Manager not running, training in progress, error code: {fabric_error}"
-    #                     custom_fields[gpu_id]["errors"].append(msg)
-    #                     custom_fields['error_count'] += 1
-    #                     custom_fields['category'].add("FabricManager")
-    #             # Persistence mode
-    #             persistence_mode = gpu_values[gpu][Wrap.fields.PERSISTENCE_MODE][0].value
-    #             triggered, _ = evaluate("ne", persistence_mode, 1)
-    #             if triggered:
-    #                 msg = f"Persistence Mode not set for GPU: {gpu}, Restart nvidia-persistenced or Reboot the system."
-    #                 custom_fields[gpu_id]["errors"].append(msg)
-    #                 custom_fields['error_count'] += 1
-    #                 custom_fields['category'].add("System")
-    #             # Row Remap failures
-    #             row_remap_failure = gpu_values[gpu][Wrap.fields.ROW_REMAP_FAIL][0].value
-    #             triggered, _ = evaluate("ne", row_remap_failure, 0)
-    #             if triggered:
-    #                 msg = f"GPU {gpu}: {dcgm_errors.DCGM_FR_ROW_REMAP_FAILURE_MSG} {dcgm_errors.DCGM_FR_ROW_REMAP_FAILURE_NEXT}"
-    #                 custom_fields[gpu_id]["errors"].append(msg)
-    #                 custom_fields['error_count'] += 1
-    #                 custom_fields['category'].add("Memory")
-    #             # DBE error
-    #             dbe_error = gpu_values[gpu][Wrap.fields.DBE_ERRORS][0].value
-    #             triggered, _ = evaluate("gt", dbe_error, 0)
-    #             if triggered:
-    #                 msg = f"{dcgm_errors.DCGM_FR_VOLATILE_DBE_DETECTED_MSG % (dbe_error, gpu)} {dcgm_errors.DCGM_FR_VOLATILE_DBE_DETECTED_NEXT}"
-    #                 custom_fields[gpu_id]["errors"].append(msg)
-    #                 custom_fields['error_count'] += 1
-    #                 custom_fields['category'].add("Memory")
-    #             # XID - read latest, deduplicate by xid number per GPU, keep earliest timestamp
-    #             xid_samples = gpu_values[gpu].get(Wrap.fields.XID_ERRORS, [])
-    #             if gpu_id not in self.xid_history:
-    #                 self.xid_history[gpu_id] = {}
-    #             for sample in xid_samples:
-    #                 if not sample.isBlank:
-    #                     xid_num = sample.value
-    #                     ts_utc = datetime.fromtimestamp(sample.ts / 1_000_000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S UTC")
-    #                     if xid_num not in self.xid_history[gpu_id] or ts_utc < self.xid_history[gpu_id][xid_num]["timestamp"]:
-    #                         self.xid_history[gpu_id][xid_num] = {"xid": xid_num, "timestamp": ts_utc}
-
-    #         # Populate report with full XID history
-    #         for gpu_id, xids in self.xid_history.items():
-    #             custom_fields.setdefault(gpu_id, self._gpu_entry())
-    #             for entry in xids.values():
-    #                 xid_num = entry["xid"]
-    #                 if xid_num in self.XID_IGNORE:
-    #                     severity = "ignore"
-    #                 elif xid_num in self.XID_WARNING:
-    #                     severity = "warning"
-    #                 else:
-    #                     severity = "error"
-    #                     custom_fields['error_count'] += 1
-    #                 custom_fields[gpu_id]['xid'].append({**entry, "severity": severity})
-    #             if xids:
-    #                 custom_fields['category'].add("XID")
-
-    #         return custom_fields
-    #     except Exception as e:
-    #         log.exception(e)
-    #         return custom_fields
 
     @healthcheck("GpuMemoryCheck", args=["gpu_id"], description="Run GPU memory allocation test. Args: gpu_id=0,1")
     @epilog
@@ -450,7 +342,6 @@ class GpuHealthChecks(HealthModule):
         custom_fields = {}
         try:
             try:
-                details = list()
                 subsystems = set()
                 report = HealthReport()
                 if not self.dcgmGroup:
@@ -499,7 +390,26 @@ class GpuHealthChecks(HealthModule):
 
                 description = f"{health_system} report {custom_fields['error_count']} errors of type {', '.join(custom_fields['category'])}"
                 report.description = description
-                report.details = '\n'.join(details)
+
+                all_errors = []
+                all_warnings = []
+                for key, val in custom_fields.items():
+                    if not isinstance(val, dict):
+                        continue
+                    for err in val.get("errors", []):
+                        all_errors.append(f"{err}")
+                    for warn in val.get("warnings", []):
+                        all_warnings.append(f"{warn}")
+
+                parts = []
+                if all_errors:
+                    parts.append("--- ERRORS ---")
+                    parts.extend(all_errors)
+                if all_warnings:
+                    parts.append("--- WARNINGS ---")
+                    parts.extend(all_warnings)
+                report.details = '\n'.join(parts)
+
                 await self.reporter.update_report(name=health_system, report=report)
                 return
 
@@ -625,10 +535,31 @@ def run_active_healthchecksv2(gpu_id: list = None, tests: str = '', params: str 
             else:
                 custom_fields[entity_id]['suppressed'].append({"msg": error_msg, "note": Wrap.DIAG_SUPPRESSED_NOTE})
     if not isHealthy:
-        #report.details = "\n".join(failures)
         report.description = "Active Diagnostic test failures"
         report.message = "GPU Epilog Errors"
         report.custom_fields = custom_fields
+
+        all_errors = []
+        all_warnings = []
+        for key, val in custom_fields.items():
+            if not isinstance(val, dict):
+                continue
+            for err in val.get("errors", []):
+                all_errors.append(f"[{key}] {err}")
+            for warn in val.get("warnings", []):
+                if isinstance(warn, dict):
+                    all_warnings.append(f"[{key}] {warn['msg']}")
+                else:
+                    all_warnings.append(f"[{key}] {warn}")
+
+        parts = []
+        if all_errors:
+            parts.append("--- ERRORS ---")
+            parts.extend(all_errors)
+        if all_warnings:
+            parts.append("--- WARNINGS ---")
+            parts.extend(all_warnings)
+        report.details = '\n'.join(parts)
 
     Wrap.disconnect(dcgmHandle, dcgmGroup)
     return report

--- a/healthagent/gpu.py
+++ b/healthagent/gpu.py
@@ -11,6 +11,7 @@ from healthagent.config import GpuConfig
 from healthagent.reporter import Reporter, HealthReport,HealthStatus
 from healthagent.util import evaluate
 from healthagent.bindings import *
+from healthagent.bindings import resolve_config_field_watches
 
 log = logging.getLogger('healthagent')
 
@@ -36,6 +37,14 @@ class GpuHealthChecks(HealthModule):
     def __init__(self, reporter: Reporter, config: 'GpuConfig | None' = None):
 
         super().__init__(reporter, config or GpuConfig())
+
+        # XID classification lists from config
+        self.xid_warning = set(self.config.xid.warning)
+        self.xid_ignore = set(self.config.xid.ignore)
+        self.xid_error = set(self.config.xid.error)
+
+        # Resolve field watches from config
+        self.field_watches = resolve_config_field_watches(self.config.field_watches)
 
         # TODO: Move this to config file
         self.test_mode = os.getenv('DCGM_TEST_MODE', 'false').lower() == 'true'
@@ -88,7 +97,7 @@ class GpuHealthChecks(HealthModule):
         with DCGM for polling.
         """
         system_fields = Wrap.get_fields()
-        watch_fields = [w["field_id"] for w in Wrap.default_field_watches]
+        watch_fields = [w["field_id"] for w in self.field_watches]
         all_fields = list(dict.fromkeys(system_fields + watch_fields))
         self.field_group = DcgmFieldGroup.DcgmFieldGroup(self.dcgmHandle, name="ccfield_group", fieldIds=all_fields)
         # UpdateFreq is in microseconds. So we are updating every 1 second.
@@ -151,18 +160,13 @@ class GpuHealthChecks(HealthModule):
             log.exception(e)
             return
 
-    # TODO: Adding all config file attributes as class objects for now.
-    XID_WARNING = [43, 63, 13, 31, 66, 94, 154]
-    XID_IGNORE = []
-    XID_ERROR = []
-
     @staticmethod
     def _gpu_entry():
         return {"errors": [], "warnings": [], "xid": []}
 
     def track_fieldsv2(self):
         """
-        Generic field watch evaluation driven by Wrap.default_field_watches.
+        Generic field watch evaluation driven by self.field_watches (from config).
         Iterates all entity groups returned by DCGM. GPU entities get per-GPU
         entries (GPU_0, GPU_1). Non-GPU entities report under 'overall'.
         XIDs are handled separately — GPU-only, not part of field watches.
@@ -192,7 +196,7 @@ class GpuHealthChecks(HealthModule):
                         entity_key = "overall"
                         custom_fields.setdefault(entity_key, {"errors": [], "warnings": []})
 
-                    for watch in Wrap.default_field_watches:
+                    for watch in self.field_watches:
                         samples = field_values.get(watch["field_id"])
                         if not samples or samples[0].isBlank:
                             continue
@@ -256,10 +260,13 @@ class GpuHealthChecks(HealthModule):
                 for entry in xids.values():
                     xid_num = entry["xid"]
                     timestamp = entry["timestamp"]
-                    if xid_num in self.XID_IGNORE:
+                    if xid_num in self.xid_ignore:
                         continue
                     msg = f"[{gpu_id}] XID {xid_num} at {timestamp}"
-                    if xid_num in self.XID_WARNING:
+                    if xid_num in self.xid_warning:
+                        custom_fields[gpu_id]['warnings'].append(msg)
+                    elif self.xid_error and xid_num not in self.xid_error:
+                        # Explicit error list provided: only those XIDs are errors
                         custom_fields[gpu_id]['warnings'].append(msg)
                     else:
                         custom_fields[gpu_id]['errors'].append(msg)

--- a/healthagent/gpu.py
+++ b/healthagent/gpu.py
@@ -4,7 +4,7 @@ import logging
 import os
 import shutil
 from datetime import datetime, timezone
-from healthagent import epilog,status,healthcheck
+from healthagent import epilog,status,healthcheck,prolog
 from healthagent.scheduler import Scheduler
 from healthagent.healthmodule import HealthModule
 from healthagent.config import GpuConfig
@@ -244,6 +244,7 @@ class GpuHealthChecks(HealthModule):
 
     @healthcheck("GpuMemoryCheck", args=["gpu_id"], description="Run GPU memory allocation test. Args: gpu_id=0,1")
     @epilog
+    @prolog
     async def memory_allocation_test(self, gpu_id: list = None):
         health_system = self.memory_allocation_test.report_name
         report = HealthReport()
@@ -278,11 +279,19 @@ class GpuHealthChecks(HealthModule):
         response[health_system] = report.view()
         return response
 
-    @healthcheck("GpuDiagnosticCheck", description="Run dcgm diagnostics checks")
+    DIAG_DEFAULTS = {
+        "prolog": {"tests": "short", "params": ""},
+        "epilog": {"tests": "medium", "params": ""},
+    }
+    @healthcheck("GpuDiagnosticCheck", description="Run DCGM diagnostics checks. Eg. Args: gpu_id=0,1 tests=memory", args=['gpu_id','tests', 'params'])
     @epilog
-    async def run_epilog(self):
-        health_system = self.run_epilog.report_name
-        report = await Scheduler.add_task(run_active_healthchecksv2)
+    @prolog
+    async def run_diag(self, gpu_id: list = None, tests: str = '', params: str = '', _phase: str = None):
+        phase_defaults = self.DIAG_DEFAULTS.get(_phase, {})
+        tests = tests or phase_defaults.get("tests", "")
+        params = params or phase_defaults.get("params", "")
+        health_system = self.run_diag.report_name
+        report = await Scheduler.add_task(run_active_healthchecksv2, gpu_id=gpu_id, tests=tests, params=params)
         await self.reporter.update_report(name=health_system, report=report)
         response = {}
         response[health_system] = report.view()
@@ -391,7 +400,7 @@ def _diag_entry():
     return {"errors": [], "warnings": [], "suppressed": []}
 
 @Scheduler.pool
-def run_active_healthchecksv2():
+def run_active_healthchecksv2(gpu_id: list = None, tests: str = '', params: str = ''):
 
     """
     Run active healthchecks, before or after a job.
@@ -411,11 +420,12 @@ def run_active_healthchecksv2():
         diag_log = os.path.join(log_dir, "nvvs_diag.log")
 
         dcgmGroup, dcgmHandle = Wrap.connect(grp_name="epilog")
-        gpu_ids = dcgmGroup.GetGpuIds()
-        params = "memory.minimum_allocation_percentage=90;memory.is_allowed=true"
-        #TODO: Later we can make this list come based on background health check errors. For example, only run pcie test if we detected pcie issues.
-        tests = "memory,pcie"
-        dd = DcgmDiag.DcgmDiag(gpuIds=gpu_ids, testNamesStr=tests, paramsStr=params)
+        if gpu_id is None:
+            gpu_id = dcgmGroup.GetGpuIds()
+
+        #params = "memory.minimum_allocation_percentage=90;memory.is_allowed=true"
+        #tests = "software,memory,pcie"
+        dd = DcgmDiag.DcgmDiag(gpuIds=gpu_id, testNamesStr=tests, paramsStr=params)
 
         if os.path.exists(log_dir):
             # Rotate if file is too large ( > 50MB)

--- a/healthagent/gpu.py
+++ b/healthagent/gpu.py
@@ -14,6 +14,17 @@ from healthagent.bindings import *
 
 log = logging.getLogger('healthagent')
 
+# Maximum number of samples to retain per field per entity.
+# At 1s polling, 300 = 5-minute window for delta_gt rate computation.
+MAX_KEEP_SAMPLES = 300
+
+# Field-specific enrichments: map field ID -> callable(raw_value, field_values) -> list[str].
+# Applied *after* generic message formatting to decode field values into
+# human-readable details. Independent of watch config (defaults or user overrides).
+_FIELD_ENRICHMENTS = {
+    dcgm_fields.DCGM_FI_DEV_CLOCKS_EVENT_REASONS: Wrap.get_throttle_reasons,
+}
+
 class GpuHealthChecksException(Exception):
     pass
 
@@ -73,14 +84,19 @@ class GpuHealthChecks(HealthModule):
     def setup_background_watches(self):
         """
         Setup field watches and health watches.
+        Registers system fields (reference, XID) + watch fields (health evaluation)
+        with DCGM for polling.
         """
-        self.watch_fields = Wrap.get_fields()
-        self.field_group = DcgmFieldGroup.DcgmFieldGroup(self.dcgmHandle, name="ccfield_group", fieldIds=self.watch_fields)
+        system_fields = Wrap.get_fields()
+        watch_fields = [w["field_id"] for w in Wrap.default_field_watches]
+        all_fields = list(dict.fromkeys(system_fields + watch_fields))
+        self.field_group = DcgmFieldGroup.DcgmFieldGroup(self.dcgmHandle, name="ccfield_group", fieldIds=all_fields)
         # UpdateFreq is in microseconds. So we are updating every 1 second.
-        # maxKeepSamples=300 bounds memory. We read the latest value each cycle.
-        self.dcgmGroup.samples.WatchFields(fieldGroup=self.field_group, updateFreq=1000000, maxKeepAge=0, maxKeepSamples=300)
+        self.dcgmGroup.samples.WatchFields(fieldGroup=self.field_group, updateFreq=1000000, maxKeepAge=0, maxKeepSamples=MAX_KEEP_SAMPLES)
         ## Add the health watches
         self.dcgmGroup.health.Set(Wrap.get_health_mask())
+        # Seed the persistent sample collection (first call with None returns latest values)
+        self._field_collection = self.dcgmGroup.samples.GetAllSinceLastCall_v2(None, self.field_group)
 
     def __display_gpu_config(self):
 
@@ -147,171 +163,92 @@ class GpuHealthChecks(HealthModule):
     def track_fieldsv2(self):
         """
         Generic field watch evaluation driven by Wrap.default_field_watches.
-        Reads DCGM field values and evaluates each watch against its thresholds.
-        XIDs are handled separately — not part of field watches.
+        Iterates all entity groups returned by DCGM. GPU entities get per-GPU
+        entries (GPU_0, GPU_1). Non-GPU entities report under 'overall'.
+        XIDs are handled separately — GPU-only, not part of field watches.
         """
         custom_fields = {'error_count': 0, 'category': set()}
         try:
-            response = self.dcgmGroup.samples.GetLatest_v2(self.field_group)
-            gpu_values = response.values.get(dcgm_fields.DCGM_FE_GPU, {})
-            for gpu in gpu_values:
-                gpu_id = f'GPU_{gpu}'
-                custom_fields.setdefault(gpu_id, self._gpu_entry())
+            # Accumulate new samples since last call
+            self._field_collection = self.dcgmGroup.samples.GetAllSinceLastCall_v2(
+                self._field_collection, self.field_group)
 
-                for watch in Wrap.default_field_watches:
-                    samples = gpu_values[gpu].get(watch["field_id"])
-                    if not samples or samples[0].isBlank:
-                        continue
+            # Trim each time series to MAX_KEEP_SAMPLES to bound memory
+            for entity_group_id, entities in self._field_collection.values.items():
+                for entity_id, fields in entities.items():
+                    for field_id, ts in fields.items():
+                        if len(ts.values) > MAX_KEEP_SAMPLES:
+                            ts.values = ts.values[-MAX_KEEP_SAMPLES:]
 
-                    newest, oldest = samples[0], samples[-1]
-                    severity = None
-                    threshold_used = None
-                    evaluated = None
-                    for level in ("error", "warning"):
-                        thresh = watch.get(level)
-                        if thresh is None:
+            for entity_group_id, entities in self._field_collection.values.items():
+                group_name = Wrap.ENTITY_GROUP_NAMES.get(entity_group_id, f"Entity_{entity_group_id}")
+                is_gpu = (entity_group_id == dcgm_fields.DCGM_FE_GPU)
+
+                for entity_id, field_values in entities.items():
+                    if is_gpu:
+                        entity_key = f"GPU_{entity_id}"
+                        custom_fields.setdefault(entity_key, self._gpu_entry())
+                    else:
+                        entity_key = "overall"
+                        custom_fields.setdefault(entity_key, {"errors": [], "warnings": []})
+
+                    for watch in Wrap.default_field_watches:
+                        samples = field_values.get(watch["field_id"])
+                        if not samples or samples[0].isBlank:
                             continue
-                        triggered, evaluated = evaluate(
-                            watch["eval"], newest.value, thresh,
-                            prev_value=oldest.value,
-                            prev_time=oldest.ts,
-                            current_time=newest.ts,
-                            window=watch.get("window", 60),
-                        )
-                        if triggered:
-                            severity = level
-                            threshold_used = thresh
-                            break
 
-                    if severity is None:
-                        continue
+                        newest, oldest = samples[-1], samples[0]
+                        #log.debug(f"Field {watch['field']} entity {entity_id}: {len(samples)} samples, oldest={oldest.value} ts={oldest.ts}, newest={newest.value} ts={newest.ts}")
+                        severity = None
+                        threshold_used = None
+                        evaluated = None
+                        for level in ("error", "warning"):
+                            thresh = watch.get(level)
+                            if thresh is None:
+                                continue
+                            triggered, evaluated = evaluate(
+                                watch["eval"], newest.value, thresh,
+                                prev_value=oldest.value,
+                                prev_time=oldest.ts / 1_000_000,
+                                current_time=newest.ts / 1_000_000,
+                                window=watch.get("window", 60),
+                            )
+                            if triggered:
+                                severity = level
+                                threshold_used = thresh
+                                break
 
-                    msg = watch["message"].format(gpu=gpu, value=evaluated, threshold=threshold_used)
-                    custom_fields[gpu_id]["errors" if severity == "error" else "warnings"].append(msg)
-                    if severity == "error":
-                        custom_fields['error_count'] += 1
-                    custom_fields['category'].add(watch["category"])
+                        if severity is None:
+                            continue
 
-                # XID - read latest, deduplicate by xid number per GPU, keep earliest timestamp
-                xid_samples = gpu_values[gpu].get(Wrap.fields.XID_ERRORS, [])
-                if gpu_id not in self.xid_history:
-                    self.xid_history[gpu_id] = {}
-                for sample in xid_samples:
-                    if not sample.isBlank:
-                        xid_num = sample.value
-                        ts_utc = datetime.fromtimestamp(sample.ts / 1_000_000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S UTC")
-                        if xid_num not in self.xid_history[gpu_id] or ts_utc < self.xid_history[gpu_id][xid_num]["timestamp"]:
-                            self.xid_history[gpu_id][xid_num] = {"xid": xid_num, "timestamp": ts_utc}
+                        if is_gpu:
+                            msg = watch["message"].format(gpu=entity_id, value=evaluated, threshold=threshold_used)
+                        else:
+                            msg = f"[{group_name}_{entity_id}] " + watch["message"].format(gpu=entity_id, value=evaluated, threshold=threshold_used)
 
-            # Populate report with full XID history
-            for gpu_id, xids in self.xid_history.items():
-                custom_fields.setdefault(gpu_id, self._gpu_entry())
-                for entry in xids.values():
-                    xid_num = entry["xid"]
-                    if xid_num in self.XID_IGNORE:
-                        severity = "ignore"
-                    elif xid_num in self.XID_WARNING:
-                        severity = "warning"
-                    else:
-                        severity = "error"
-                        custom_fields['error_count'] += 1
-                    custom_fields[gpu_id]['xid'].append({**entry, "severity": severity})
-                if xids:
-                    custom_fields['category'].add("XID")
+                        enrich = _FIELD_ENRICHMENTS.get(watch["field_id"])
+                        if enrich:
+                            details = enrich(newest.value, field_values)
+                            if details:
+                                msg += " \u2014 " + "; ".join(details)
 
-            return custom_fields
-        except Exception as e:
-            log.exception(e)
-            return custom_fields
-    def track_fields(self):
+                        custom_fields[entity_key]["errors" if severity == "error" else "warnings"].append(msg)
+                        if severity == "error":
+                            custom_fields['error_count'] += 1
+                        custom_fields['category'].add(watch["category"])
 
-        """
-        Read field values from DCGM.
-        All fields (polled and event-driven) are read via GetLatest_v2.
-        XIDs are deduplicated and accumulated in self.xid_history for the node's lifetime.
-        """
-
-        custom_fields = {}
-        custom_fields['error_count'] = 0
-        custom_fields['category'] = set()
-        try:
-            response = self.dcgmGroup.samples.GetLatest_v2(self.field_group)
-            gpu_values = response.values.get(dcgm_fields.DCGM_FE_GPU, {})
-            for gpu in gpu_values:
-                gpu_id = f'GPU_{gpu}'
-                custom_fields.setdefault(gpu_id, self._gpu_entry())
-                # Handle Thermal
-                curr_temp = gpu_values[gpu][Wrap.fields.GPUTEMP][0].value
-                slowdown_temp = gpu_values[gpu][Wrap.fields.GPUTEMP_SLOWDOWN][0].value
-                triggered, _ = evaluate("ge", curr_temp, 0.95 * slowdown_temp)
-                if triggered:
-                    msg = f"GPU temperature reached very close to the slowdown limit gpu: {gpu} Curr temp: {curr_temp}, slowdown limit: {slowdown_temp}"
-                    custom_fields[gpu_id]["errors"].append(msg)
-                    custom_fields['error_count'] += 1
-                    custom_fields['category'].add("Thermal")
-                # Clocks
-                clock_reason = gpu_values[gpu][Wrap.fields.CLOCK_REASON][0].value
-                THROTTLE_MASK = (dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_SLOWDOWN
-                                 | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_SW_THERMAL
-                                 | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_THERMAL
-                                 | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_POWER_BRAKE)
-                triggered, _ = evaluate("bitmask", clock_reason, THROTTLE_MASK)
-                if triggered:
-                    throttle_reasons = Wrap.get_throttle_reasons(clock_reason)
-                    custom_fields[gpu_id]["errors"].append(throttle_reasons)
-                    custom_fields['error_count'] += 1
-                    custom_fields['category'].add("Clocks")
-                # Fabric errors
-                fabric_status = gpu_values[gpu][Wrap.fields.FABRIC_STATUS][0].value
-                triggered, _ = evaluate("eq", fabric_status, dcgm_structs.DcgmFMStatusFailure)
-                if triggered:
-                    fabric_error = gpu_values[gpu][Wrap.fields.FABRIC_ERROR][0].value
-                    msg = f"Fabric Manager finished training but failed, error code: {fabric_error}"
-                    custom_fields[gpu_id]["errors"].append(msg)
-                    custom_fields['error_count'] += 1
-                    custom_fields['category'].add("FabricManager")
-                else:
-                    triggered, _ = evaluate("eq", fabric_status, dcgm_structs.DcgmFMStatusInProgress)
-                    if triggered:
-                        fabric_error = gpu_values[gpu][Wrap.fields.FABRIC_ERROR][0].value
-                        msg = f"Fabric Manager not running, training in progress, error code: {fabric_error}"
-                        custom_fields[gpu_id]["errors"].append(msg)
-                        custom_fields['error_count'] += 1
-                        custom_fields['category'].add("FabricManager")
-                # Persistence mode
-                persistence_mode = gpu_values[gpu][Wrap.fields.PERSISTENCE_MODE][0].value
-                triggered, _ = evaluate("ne", persistence_mode, 1)
-                if triggered:
-                    msg = f"Persistence Mode not set for GPU: {gpu}, Restart nvidia-persistenced or Reboot the system."
-                    custom_fields[gpu_id]["errors"].append(msg)
-                    custom_fields['error_count'] += 1
-                    custom_fields['category'].add("System")
-                # Row Remap failures
-                row_remap_failure = gpu_values[gpu][Wrap.fields.ROW_REMAP_FAIL][0].value
-                triggered, _ = evaluate("ne", row_remap_failure, 0)
-                if triggered:
-                    msg = f"GPU {gpu}: {dcgm_errors.DCGM_FR_ROW_REMAP_FAILURE_MSG} {dcgm_errors.DCGM_FR_ROW_REMAP_FAILURE_NEXT}"
-                    custom_fields[gpu_id]["errors"].append(msg)
-                    custom_fields['error_count'] += 1
-                    custom_fields['category'].add("Memory")
-                # DBE error
-                dbe_error = gpu_values[gpu][Wrap.fields.DBE_ERRORS][0].value
-                triggered, _ = evaluate("gt", dbe_error, 0)
-                if triggered:
-                    msg = f"{dcgm_errors.DCGM_FR_VOLATILE_DBE_DETECTED_MSG % (dbe_error, gpu)} {dcgm_errors.DCGM_FR_VOLATILE_DBE_DETECTED_NEXT}"
-                    custom_fields[gpu_id]["errors"].append(msg)
-                    custom_fields['error_count'] += 1
-                    custom_fields['category'].add("Memory")
-                # XID - read latest, deduplicate by xid number per GPU, keep earliest timestamp
-                xid_samples = gpu_values[gpu].get(Wrap.fields.XID_ERRORS, [])
-                if gpu_id not in self.xid_history:
-                    self.xid_history[gpu_id] = {}
-                for sample in xid_samples:
-                    if not sample.isBlank:
-                        xid_num = sample.value
-                        ts_utc = datetime.fromtimestamp(sample.ts / 1_000_000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S UTC")
-                        if xid_num not in self.xid_history[gpu_id] or ts_utc < self.xid_history[gpu_id][xid_num]["timestamp"]:
-                            self.xid_history[gpu_id][xid_num] = {"xid": xid_num, "timestamp": ts_utc}
+                    # XID handling — GPU entities only
+                    if is_gpu:
+                        xid_samples = field_values.get(Wrap.fields.XID_ERRORS, [])
+                        gpu_id = entity_key
+                        if gpu_id not in self.xid_history:
+                            self.xid_history[gpu_id] = {}
+                        for sample in xid_samples:
+                            if not sample.isBlank:
+                                xid_num = sample.value
+                                ts_utc = datetime.fromtimestamp(sample.ts / 1_000_000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S UTC")
+                                if xid_num not in self.xid_history[gpu_id] or ts_utc < self.xid_history[gpu_id][xid_num]["timestamp"]:
+                                    self.xid_history[gpu_id][xid_num] = {"xid": xid_num, "timestamp": ts_utc}
 
             # Populate report with full XID history
             for gpu_id, xids in self.xid_history.items():
@@ -333,6 +270,117 @@ class GpuHealthChecks(HealthModule):
         except Exception as e:
             log.exception(e)
             return custom_fields
+
+    # def track_fields(self):
+
+    #     """
+    #     Read field values from DCGM.
+    #     All fields (polled and event-driven) are read via GetLatest_v2.
+    #     XIDs are deduplicated and accumulated in self.xid_history for the node's lifetime.
+    #     """
+
+    #     custom_fields = {}
+    #     custom_fields['error_count'] = 0
+    #     custom_fields['category'] = set()
+    #     try:
+    #         response = self.dcgmGroup.samples.GetLatest_v2(self.field_group)
+    #         gpu_values = response.values.get(dcgm_fields.DCGM_FE_GPU, {})
+    #         for gpu in gpu_values:
+    #             gpu_id = f'GPU_{gpu}'
+    #             custom_fields.setdefault(gpu_id, self._gpu_entry())
+    #             # Handle Thermal
+    #             curr_temp = gpu_values[gpu][Wrap.fields.GPUTEMP][0].value
+    #             slowdown_temp = gpu_values[gpu][Wrap.fields.GPUTEMP_SLOWDOWN][0].value
+    #             triggered, _ = evaluate("ge", curr_temp, 0.95 * slowdown_temp)
+    #             if triggered:
+    #                 msg = f"GPU temperature reached very close to the slowdown limit gpu: {gpu} Curr temp: {curr_temp}, slowdown limit: {slowdown_temp}"
+    #                 custom_fields[gpu_id]["errors"].append(msg)
+    #                 custom_fields['error_count'] += 1
+    #                 custom_fields['category'].add("Thermal")
+    #             # Clocks
+    #             clock_reason = gpu_values[gpu][Wrap.fields.CLOCK_REASON][0].value
+    #             THROTTLE_MASK = (dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_SLOWDOWN
+    #                              | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_SW_THERMAL
+    #                              | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_THERMAL
+    #                              | dcgm_fields.DCGM_CLOCKS_EVENT_REASON_HW_POWER_BRAKE)
+    #             triggered, _ = evaluate("bitmask", clock_reason, THROTTLE_MASK)
+    #             if triggered:
+    #                 throttle_reasons = Wrap.get_throttle_reasons(clock_reason)
+    #                 custom_fields[gpu_id]["errors"].append(throttle_reasons)
+    #                 custom_fields['error_count'] += 1
+    #                 custom_fields['category'].add("Clocks")
+    #             # Fabric errors
+    #             fabric_status = gpu_values[gpu][Wrap.fields.FABRIC_STATUS][0].value
+    #             triggered, _ = evaluate("eq", fabric_status, dcgm_structs.DcgmFMStatusFailure)
+    #             if triggered:
+    #                 fabric_error = gpu_values[gpu][Wrap.fields.FABRIC_ERROR][0].value
+    #                 msg = f"Fabric Manager finished training but failed, error code: {fabric_error}"
+    #                 custom_fields[gpu_id]["errors"].append(msg)
+    #                 custom_fields['error_count'] += 1
+    #                 custom_fields['category'].add("FabricManager")
+    #             else:
+    #                 triggered, _ = evaluate("eq", fabric_status, dcgm_structs.DcgmFMStatusInProgress)
+    #                 if triggered:
+    #                     fabric_error = gpu_values[gpu][Wrap.fields.FABRIC_ERROR][0].value
+    #                     msg = f"Fabric Manager not running, training in progress, error code: {fabric_error}"
+    #                     custom_fields[gpu_id]["errors"].append(msg)
+    #                     custom_fields['error_count'] += 1
+    #                     custom_fields['category'].add("FabricManager")
+    #             # Persistence mode
+    #             persistence_mode = gpu_values[gpu][Wrap.fields.PERSISTENCE_MODE][0].value
+    #             triggered, _ = evaluate("ne", persistence_mode, 1)
+    #             if triggered:
+    #                 msg = f"Persistence Mode not set for GPU: {gpu}, Restart nvidia-persistenced or Reboot the system."
+    #                 custom_fields[gpu_id]["errors"].append(msg)
+    #                 custom_fields['error_count'] += 1
+    #                 custom_fields['category'].add("System")
+    #             # Row Remap failures
+    #             row_remap_failure = gpu_values[gpu][Wrap.fields.ROW_REMAP_FAIL][0].value
+    #             triggered, _ = evaluate("ne", row_remap_failure, 0)
+    #             if triggered:
+    #                 msg = f"GPU {gpu}: {dcgm_errors.DCGM_FR_ROW_REMAP_FAILURE_MSG} {dcgm_errors.DCGM_FR_ROW_REMAP_FAILURE_NEXT}"
+    #                 custom_fields[gpu_id]["errors"].append(msg)
+    #                 custom_fields['error_count'] += 1
+    #                 custom_fields['category'].add("Memory")
+    #             # DBE error
+    #             dbe_error = gpu_values[gpu][Wrap.fields.DBE_ERRORS][0].value
+    #             triggered, _ = evaluate("gt", dbe_error, 0)
+    #             if triggered:
+    #                 msg = f"{dcgm_errors.DCGM_FR_VOLATILE_DBE_DETECTED_MSG % (dbe_error, gpu)} {dcgm_errors.DCGM_FR_VOLATILE_DBE_DETECTED_NEXT}"
+    #                 custom_fields[gpu_id]["errors"].append(msg)
+    #                 custom_fields['error_count'] += 1
+    #                 custom_fields['category'].add("Memory")
+    #             # XID - read latest, deduplicate by xid number per GPU, keep earliest timestamp
+    #             xid_samples = gpu_values[gpu].get(Wrap.fields.XID_ERRORS, [])
+    #             if gpu_id not in self.xid_history:
+    #                 self.xid_history[gpu_id] = {}
+    #             for sample in xid_samples:
+    #                 if not sample.isBlank:
+    #                     xid_num = sample.value
+    #                     ts_utc = datetime.fromtimestamp(sample.ts / 1_000_000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S UTC")
+    #                     if xid_num not in self.xid_history[gpu_id] or ts_utc < self.xid_history[gpu_id][xid_num]["timestamp"]:
+    #                         self.xid_history[gpu_id][xid_num] = {"xid": xid_num, "timestamp": ts_utc}
+
+    #         # Populate report with full XID history
+    #         for gpu_id, xids in self.xid_history.items():
+    #             custom_fields.setdefault(gpu_id, self._gpu_entry())
+    #             for entry in xids.values():
+    #                 xid_num = entry["xid"]
+    #                 if xid_num in self.XID_IGNORE:
+    #                     severity = "ignore"
+    #                 elif xid_num in self.XID_WARNING:
+    #                     severity = "warning"
+    #                 else:
+    #                     severity = "error"
+    #                     custom_fields['error_count'] += 1
+    #                 custom_fields[gpu_id]['xid'].append({**entry, "severity": severity})
+    #             if xids:
+    #                 custom_fields['category'].add("XID")
+
+    #         return custom_fields
+    #     except Exception as e:
+    #         log.exception(e)
+    #         return custom_fields
 
     @healthcheck("GpuMemoryCheck", args=["gpu_id"], description="Run GPU memory allocation test. Args: gpu_id=0,1")
     @epilog
@@ -410,13 +458,14 @@ class GpuHealthChecks(HealthModule):
                 group_health = self.dcgmGroup.health.Check()
                 incident_count = group_health.incidentCount
 
-                custom_fields = self.track_fields()
+                custom_fields = self.track_fieldsv2()
                 if custom_fields.get('error_count', 0) > 0:
                     report.escalate(HealthStatus.ERROR)
 
                 for index in range (0, incident_count):
                     entity_id = group_health.incidents[index].entityInfo.entityId
-                    if entity_id == dcgm_fields.DCGM_FE_GPU:
+                    entity_group_id = group_health.incidents[index].entityInfo.entityGroupId
+                    if entity_group_id == dcgm_fields.DCGM_FE_GPU:
                         entity = f"GPU_{entity_id}"
                         custom_fields.setdefault(entity, self._gpu_entry())
                     else:
@@ -437,7 +486,7 @@ class GpuHealthChecks(HealthModule):
                         #ignore
                         continue
 
-                #details.extend(field_errors)
+                # TRIM the output for better readability.
                 custom_fields['category'].update(subsystems)
                 report.custom_fields = {
                     k: v for k, v in custom_fields.items()
@@ -467,8 +516,8 @@ class GpuHealthChecks(HealthModule):
             try:
                 self.setup()
             except Wrap.DcgmConnectionFail as e:
-                log.critical(f"Unable to connect to DCGM: {e}")
-                log.critical("To re-instantiate checks, restart the nvidia-dcgm service.")
+                log.critical(f"Unable to instantiate or connect to DCGM: {e}")
+                log.critical("To re-instantiate checks, restart healthagent. If using DCGM_TEST_MODE, restart nvidia-dcgm.service")
             else:
                 log.info("Re-initialized our connection to DCGM.")
         except Exception as e:

--- a/healthagent/gpu.py
+++ b/healthagent/gpu.py
@@ -171,7 +171,7 @@ class GpuHealthChecks(HealthModule):
         entries (GPU_0, GPU_1). Non-GPU entities report under 'overall'.
         XIDs are handled separately — GPU-only, not part of field watches.
         """
-        custom_fields = {'error_count': 0, 'category': set()}
+        custom_fields = {'error_count': 0, 'warning_count': 0, 'category': set()}
         try:
             # Accumulate new samples since last call
             self._field_collection = self.dcgmGroup.samples.GetAllSinceLastCall_v2(
@@ -239,6 +239,8 @@ class GpuHealthChecks(HealthModule):
                         custom_fields[entity_key]["errors" if severity == "error" else "warnings"].append(msg)
                         if severity == "error":
                             custom_fields['error_count'] += 1
+                        else:
+                            custom_fields['warning_count'] += 1
                         custom_fields['category'].add(watch["category"])
 
                     # XID handling — GPU entities only
@@ -265,9 +267,11 @@ class GpuHealthChecks(HealthModule):
                     msg = f"[{gpu_id}] XID {xid_num} at {timestamp}"
                     if xid_num in self.xid_warning:
                         custom_fields[gpu_id]['warnings'].append(msg)
+                        custom_fields['warning_count'] += 1
                     elif self.xid_error and xid_num not in self.xid_error:
                         # Explicit error list provided: only those XIDs are errors
                         custom_fields[gpu_id]['warnings'].append(msg)
+                        custom_fields['warning_count'] += 1
                     else:
                         custom_fields[gpu_id]['errors'].append(msg)
                         custom_fields['error_count'] += 1
@@ -318,17 +322,14 @@ class GpuHealthChecks(HealthModule):
         response[health_system] = report.view()
         return response
 
-    DIAG_DEFAULTS = {
-        "prolog": {"tests": "short", "params": ""},
-        "epilog": {"tests": "medium", "params": ""},
-    }
     @healthcheck("GpuDiagnosticCheck", description="Run DCGM diagnostics checks. Eg. Args: gpu_id=0,1 tests=memory", args=['gpu_id','tests', 'params'])
     @epilog
     @prolog
     async def run_diag(self, gpu_id: list = None, tests: str = '', params: str = '', _phase: str = None):
-        phase_defaults = self.DIAG_DEFAULTS.get(_phase, {})
-        tests = tests or phase_defaults.get("tests", "")
-        params = params or phase_defaults.get("params", "")
+        diag_cfg = self.config.gpudiagnosticcheck
+        phase_cfg = getattr(diag_cfg, _phase, None) if _phase else None
+        tests = tests or (phase_cfg.tests if phase_cfg else "")
+        params = params or (phase_cfg.params if phase_cfg else "")
         health_system = self.run_diag.report_name
         report = await Scheduler.add_task(run_active_healthchecksv2, gpu_id=gpu_id, tests=tests, params=params)
         await self.reporter.update_report(name=health_system, report=report)
@@ -359,6 +360,8 @@ class GpuHealthChecks(HealthModule):
                 custom_fields = self.track_fieldsv2()
                 if custom_fields.get('error_count', 0) > 0:
                     report.escalate(HealthStatus.ERROR)
+                if custom_fields.get('warning_count', 0) > 0:
+                    report.escalate(HealthStatus.WARNING)
 
                 for index in range (0, incident_count):
                     entity_id = group_health.incidents[index].entityInfo.entityId
@@ -374,6 +377,7 @@ class GpuHealthChecks(HealthModule):
                     if error_code in Wrap.HEALTH_WARNINGS:
                         custom_fields[entity]['warnings'].append(group_health.incidents[index].error.msg)
                         report.escalate(HealthStatus.WARNING)
+                        custom_fields['warning_count'] += 1
                         subsystems.add(system)
                     elif error_code in Wrap.HEALTH_ERRORS:
                         report.escalate(HealthStatus.ERROR)
@@ -391,11 +395,11 @@ class GpuHealthChecks(HealthModule):
                     if not isinstance(v, dict) or any(v.values())
                 }
 
-                if custom_fields['error_count'] == 0:
+                if custom_fields['error_count'] == 0 and custom_fields['warning_count'] == 0:
                     await self.reporter.update_report(name=health_system, report=report)
                     return
 
-                description = f"{health_system} report {custom_fields['error_count']} errors of type {', '.join(custom_fields['category'])}"
+                description = f"{health_system} report {custom_fields['error_count']} errors, {custom_fields['warning_count']} warnings of type {', '.join(custom_fields['category'])}"
                 report.description = description
 
                 all_errors = []
@@ -517,9 +521,9 @@ def run_active_healthchecksv2(gpu_id: list = None, tests: str = '', params: str 
         custom_fields['error_count'] += 1
         custom_fields.setdefault('overall', _diag_entry())
         custom_fields['overall']['errors'].append(str(e))
+        report.escalate(HealthStatus.ERROR)
 
     if response and response.numErrors > 0:
-        isHealthy = False
         for errIdx in range(response.numErrors):
             curErr = response.errors[errIdx]
             error_msg = curErr.msg
@@ -530,10 +534,12 @@ def run_active_healthchecksv2(gpu_id: list = None, tests: str = '', params: str 
                 entity_id = "overall"
             custom_fields.setdefault(entity_id, _diag_entry())
             if error_code in Wrap.DIAG_ERRORS:
+                isHealthy = False
                 custom_fields[entity_id]['errors'].append(error_msg)
                 custom_fields['error_count'] += 1
                 report.escalate(HealthStatus.ERROR)
             elif error_code in Wrap.DIAG_WARNINGS:
+                isHealthy = False
                 note = Wrap.DIAG_WARNINGS[error_code]
                 custom_fields[entity_id]['warnings'].append({"msg": error_msg, "note": note})
                 report.escalate(HealthStatus.WARNING)
@@ -542,8 +548,7 @@ def run_active_healthchecksv2(gpu_id: list = None, tests: str = '', params: str 
             else:
                 custom_fields[entity_id]['suppressed'].append({"msg": error_msg, "note": Wrap.DIAG_SUPPRESSED_NOTE})
     if not isHealthy:
-        report.description = "Active Diagnostic test failures"
-        report.message = "GPU Epilog Errors"
+        report.description = "GPU Diagnostic test errors"
         report.custom_fields = custom_fields
 
         all_errors = []

--- a/healthagent/healthmodule.py
+++ b/healthagent/healthmodule.py
@@ -180,6 +180,10 @@ class HealthModule(ABC):
                                   f"does not accept user arguments. Ignoring kwargs.")
                         kwargs = {}
                     kwargs = self._coerce_kwargs(handler, kwargs)
+                # Inject _phase so handlers can apply phase-specific defaults
+                sig = inspect.signature(handler)
+                if '_phase' in sig.parameters:
+                    kwargs['_phase'] = attribute_flag
                 if inspect.iscoroutinefunction(handler):
                     ans = await handler(**kwargs)
                 else:

--- a/healthagent/healthmodule.py
+++ b/healthagent/healthmodule.py
@@ -182,6 +182,10 @@ class HealthModule(ABC):
                                   f"does not accept user arguments. Ignoring kwargs.")
                         kwargs = {}
                     kwargs = self._coerce_kwargs(handler, kwargs)
+                # Inject _phase so handlers can apply phase-specific defaults
+                sig = inspect.signature(handler)
+                if '_phase' in sig.parameters:
+                    kwargs['_phase'] = attribute_flag
                 if inspect.iscoroutinefunction(handler):
                     ans = await handler(**kwargs)
                 else:

--- a/healthagent/install.py
+++ b/healthagent/install.py
@@ -6,7 +6,7 @@ def main():
     os.makedirs(etc_dir, exist_ok=True)
 
     # Copy example scripts
-    for fname in ["health.sh.example", "epilog.sh.example"]:
+    for fname in ["health.sh.example", "epilog.sh.example", "prolog.sh.example"]:
         src = os.path.join(os.path.dirname(__file__), "etc", fname)
         dst = os.path.join(etc_dir, fname)
         shutil.copy2(src, dst)

--- a/healthagent/install.py
+++ b/healthagent/install.py
@@ -14,7 +14,7 @@ def main():
     print(f"Copied defaults.yaml to {defaults_dst}")
 
     # Copy example scripts
-    for fname in ["health.sh.example", "epilog.sh.example"]:
+    for fname in ["health.sh.example", "epilog.sh.example", "prolog.sh.example"]:
         src = os.path.join(os.path.dirname(__file__), "etc", fname)
         dst = os.path.join(etc_dir, fname)
         shutil.copy2(src, dst)

--- a/integration/test_inject.py
+++ b/integration/test_inject.py
@@ -65,6 +65,7 @@ FI_RECOVERY_ACTION           = 1523
 FI_ECC_SBE_AGG_TOTAL         = 312
 FI_PCIE_REPLAY_COUNTER       = 202
 FI_FABRIC_HEALTH_MASK        = 174
+FI_XID_ERRORS                = 230
 
 
 # ── Test functions ─────────────────────────────────────────────
@@ -145,6 +146,13 @@ def test_sbe_rate(gpu_id, duration):
     inject_loop(gpu_id, FI_ECC_SBE_AGG_TOTAL, 99999, duration, "SBE_AGG_TOTAL")
 
 
+def test_xid(gpu_id, duration):
+    """Inject XID errors — one error XID (48) and one warning XID (63)."""
+    print(f"\n=== GPU {gpu_id}: XID errors (warning=[43,63,13,31,66,94,154], else error) ===")
+    inject_loop(gpu_id, FI_XID_ERRORS, 48, duration, "XID 48 (error)")
+    inject_loop(gpu_id, FI_XID_ERRORS, 63, duration, "XID 63 (warning)")
+
+
 def test_clear(gpu_id, duration):
     """Inject healthy values to clear previous injections."""
     print(f"\n=== GPU {gpu_id}: Clearing — injecting healthy values ===")
@@ -160,6 +168,7 @@ def test_clear(gpu_id, duration):
         (FI_RECOVERY_ACTION, 0, "RECOVERY_ACTION"),
         (FI_ECC_SBE_AGG_TOTAL, 0, "SBE_AGG_TOTAL"),
         (FI_PCIE_REPLAY_COUNTER, 0, "PCIE_REPLAY_COUNTER"),
+        (FI_XID_ERRORS, 0, "XID_ERRORS"),
     ]
     for field_id, value, name in clears:
         ok = inject(gpu_id, field_id, value)
@@ -180,6 +189,7 @@ TESTS = {
     "fabric_health": test_fabric_health,
     "recovery": test_recovery_action,
     "sberate":  test_sbe_rate,
+    "xid":      test_xid,
     "clear":    test_clear,
 }
 

--- a/integration/test_inject.py
+++ b/integration/test_inject.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+Inject DCGM field values for testing healthagent field watches.
+Uses `dcgmi test --inject` CLI (official DCGM error injection API).
+Requires DCGM hostengine running in standalone mode (nvidia-dcgm.service)
+and healthagent started with DCGM_TEST_MODE=true.
+
+Injected values expire from DCGM cache quickly, so the --duration flag
+re-injects every second for the specified period.
+
+Usage:
+    python3 test_inject.py [--gpu 0] [--test all|temp|clocks|...] [--duration 120]
+
+Examples:
+    # Run all injection tests on GPU 0, keep injecting for 2 minutes
+    python3 test_inject.py --test all --duration 120
+
+    # Inject high temperature on GPU 1 for 60 seconds
+    python3 test_inject.py --gpu 1 --test temp --duration 60
+
+    # Clear injected values (inject healthy values)
+    python3 test_inject.py --test clear
+"""
+import sys
+import time
+import argparse
+import subprocess
+
+
+def inject(gpu_id, field_id, value):
+    """Inject a field value using dcgmi test --inject."""
+    cmd = ["dcgmi", "test", "--inject", "--gpuid", str(gpu_id),
+           "-f", str(field_id), "-v", str(value)]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    ok = result.returncode == 0 and "Successfully" in result.stdout
+    return ok
+
+
+def inject_loop(gpu_id, field_id, value, duration, name):
+    """Re-inject a value every second for duration seconds."""
+    ok = inject(gpu_id, field_id, value)
+    _report(name, str(value), ok)
+    if duration > 1:
+        end_time = time.time() + duration
+        while time.time() < end_time:
+            time.sleep(1)
+            inject(gpu_id, field_id, value)
+
+
+def _report(name, value_str, ok):
+    status = "OK" if ok else "FAIL"
+    print(f"  {name} = {value_str}  ->  {status}")
+
+
+# ── Field IDs (from dcgm_fields.h) ────────────────────────────
+# Using integer IDs directly so we don't need DCGM Python bindings
+FI_GPU_TEMP                  = 150
+FI_CLOCKS_EVENT_REASONS      = 112
+FI_PERSISTENCE_MODE          = 65
+FI_ECC_DBE_VOL_TOTAL         = 311
+FI_ROW_REMAP_FAILURE         = 395
+FI_RETIRED_SBE               = 390
+FI_FABRIC_MANAGER_STATUS     = 170
+FI_RECOVERY_ACTION           = 1523
+FI_ECC_SBE_AGG_TOTAL         = 312
+FI_PCIE_REPLAY_COUNTER       = 202
+FI_FABRIC_HEALTH_MASK        = 174
+
+
+# ── Test functions ─────────────────────────────────────────────
+
+def test_temperature(gpu_id, duration):
+    """Inject GPU temp 95°C — triggers gt error (> 90)."""
+    print(f"\n=== GPU {gpu_id}: Temperature (warning > 83, error > 90) ===")
+    inject_loop(gpu_id, FI_GPU_TEMP, 95, duration, "GPU_TEMP (error)")
+
+
+def test_clocks(gpu_id, duration):
+    """Inject clock throttle reasons — triggers bitmask error (0xE8)."""
+    print(f"\n=== GPU {gpu_id}: CLOCKS_EVENT_REASONS = 0xE8 (all throttle bits) ===")
+    inject_loop(gpu_id, FI_CLOCKS_EVENT_REASONS, 0xE8, duration, "CLOCKS_EVENT_REASONS")
+
+
+def test_pcie_replay(gpu_id, duration):
+    """Inject high PCIe replay counter — triggers delta_gt."""
+    print(f"\n=== GPU {gpu_id}: PCIe replay counter (delta_gt warning > 50, error > 200) ===")
+    inject_loop(gpu_id, FI_PCIE_REPLAY_COUNTER, 99999, duration, "PCIE_REPLAY_COUNTER")
+
+
+def test_persistence_mode(gpu_id, duration):
+    """Inject persistence mode = 0 — triggers ne 1 error."""
+    print(f"\n=== GPU {gpu_id}: Persistence mode (error if != 1) ===")
+    inject_loop(gpu_id, FI_PERSISTENCE_MODE, 0, duration, "PERSISTENCE_MODE")
+
+
+def test_dbe(gpu_id, duration):
+    """Inject volatile DBE error — triggers gt 0 error."""
+    print(f"\n=== GPU {gpu_id}: Volatile DBE (error if > 0) ===")
+    inject_loop(gpu_id, FI_ECC_DBE_VOL_TOTAL, 1, duration, "DBE_VOL_TOTAL")
+
+
+def test_row_remap(gpu_id, duration):
+    """Inject row remap failure — triggers ne 0 error."""
+    print(f"\n=== GPU {gpu_id}: Row remap failure (error if != 0) ===")
+    inject_loop(gpu_id, FI_ROW_REMAP_FAILURE, 1, duration, "ROW_REMAP_FAILURE")
+
+
+def test_retired_sbe(gpu_id, duration):
+    """Inject retired SBE pages = 65 — triggers gt error (> 63)."""
+    print(f"\n=== GPU {gpu_id}: Retired SBE pages (warning > 50, error > 63) ===")
+    inject_loop(gpu_id, FI_RETIRED_SBE, 65, duration, "RETIRED_SBE (error)")
+
+
+def test_fabric_status(gpu_id, duration):
+    """Inject fabric manager failure (status=4) — triggers DCGM_FR_FABRIC_PROBE_STATE via health watch."""
+    print(f"\n=== GPU {gpu_id}: Fabric Manager status (error if in [4, 1]) ===")
+    inject_loop(gpu_id, FI_FABRIC_MANAGER_STATUS, 4, duration, "FABRIC_STATUS (failure)")
+
+
+def test_fabric_health(gpu_id, duration):
+    """Inject fabric health mask with ROUTE_UNHEALTHY=TRUE — triggers DCGM_FR_FIELD_VIOLATION via health watch.
+
+    Bitmask layout (from nvml.h):
+      [1:0]  DEGRADED_BW              (0=NOT_SUPPORTED, 1=TRUE, 2=FALSE)
+      [3:2]  ROUTE_RECOVERY           (0=NOT_SUPPORTED, 1=TRUE, 2=FALSE)
+      [5:4]  ROUTE_UNHEALTHY          (0=NOT_SUPPORTED, 1=TRUE, 2=FALSE)
+      [7:6]  ACCESS_TIMEOUT_RECOVERY  (0=NOT_SUPPORTED, 1=TRUE, 2=FALSE)
+      [11:8] INCORRECT_CONFIGURATION  (0=NOT_SUPPORTED, 1=NONE, ...)
+
+    Healthy = 0x1AA (all FALSE/NONE).  Unhealthy = 0x19A (ROUTE_UNHEALTHY=TRUE).
+    """
+    print(f"\n=== GPU {gpu_id}: Fabric Health Mask (ROUTE_UNHEALTHY=TRUE) ===")
+    inject_loop(gpu_id, FI_FABRIC_HEALTH_MASK, 0x19A, duration, "FABRIC_HEALTH_MASK (route_unhealthy)")
+
+
+def test_recovery_action(gpu_id, duration):
+    """Inject recovery action = 3 (GPU_RESET) — triggers in [3, 4] error."""
+    print(f"\n=== GPU {gpu_id}: Recovery action (warning [2], error [3, 4]) ===")
+    inject_loop(gpu_id, FI_RECOVERY_ACTION, 3, duration, "RECOVERY_ACTION (GPU_RESET)")
+
+
+def test_sbe_rate(gpu_id, duration):
+    """Inject high SBE aggregate counter — triggers delta_gt."""
+    print(f"\n=== GPU {gpu_id}: SBE aggregate rate (delta_gt warning > 100/min) ===")
+    inject_loop(gpu_id, FI_ECC_SBE_AGG_TOTAL, 99999, duration, "SBE_AGG_TOTAL")
+
+
+def test_clear(gpu_id, duration):
+    """Inject healthy values to clear previous injections."""
+    print(f"\n=== GPU {gpu_id}: Clearing — injecting healthy values ===")
+    clears = [
+        (FI_GPU_TEMP, 45, "GPU_TEMP"),
+        (FI_CLOCKS_EVENT_REASONS, 0, "CLOCKS_EVENT_REASONS"),
+        (FI_PERSISTENCE_MODE, 1, "PERSISTENCE_MODE"),
+        (FI_ECC_DBE_VOL_TOTAL, 0, "DBE_VOL_TOTAL"),
+        (FI_ROW_REMAP_FAILURE, 0, "ROW_REMAP_FAILURE"),
+        (FI_RETIRED_SBE, 0, "RETIRED_SBE"),
+        (FI_FABRIC_MANAGER_STATUS, 3, "FABRIC_STATUS (success)"),
+        (FI_FABRIC_HEALTH_MASK, 0x1AA, "FABRIC_HEALTH_MASK (healthy)"),
+        (FI_RECOVERY_ACTION, 0, "RECOVERY_ACTION"),
+        (FI_ECC_SBE_AGG_TOTAL, 0, "SBE_AGG_TOTAL"),
+        (FI_PCIE_REPLAY_COUNTER, 0, "PCIE_REPLAY_COUNTER"),
+    ]
+    for field_id, value, name in clears:
+        ok = inject(gpu_id, field_id, value)
+        _report(name, str(value), ok)
+
+
+# ── Main ───────────────────────────────────────────────────────
+
+TESTS = {
+    "temp":     test_temperature,
+    "clocks":   test_clocks,
+    "pcie":     test_pcie_replay,
+    "persist":  test_persistence_mode,
+    "dbe":      test_dbe,
+    "remap":    test_row_remap,
+    "sbe":      test_retired_sbe,
+    "fabric":   test_fabric_status,
+    "fabric_health": test_fabric_health,
+    "recovery": test_recovery_action,
+    "sberate":  test_sbe_rate,
+    "clear":    test_clear,
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Inject DCGM field values for testing healthagent")
+    parser.add_argument("--gpu", type=int, default=0, help="GPU ID to inject into (default: 0)")
+    parser.add_argument("--test", type=str, default="all",
+                        choices=["all"] + list(TESTS.keys()),
+                        help="Which test to run (default: all)")
+    parser.add_argument("--duration", type=int, default=120,
+                        help="How long to keep re-injecting values in seconds (default: 120)")
+    args = parser.parse_args()
+
+    # Verify dcgmi is available
+    result = subprocess.run(["which", "dcgmi"], capture_output=True)
+    if result.returncode != 0:
+        print("Error: dcgmi not found. Is DCGM installed?")
+        sys.exit(1)
+
+    gpu_id = args.gpu
+    duration = args.duration
+    print(f"Target GPU: {gpu_id}, Duration: {duration}s")
+
+    if args.test == "all":
+        for name, func in TESTS.items():
+            if name == "clear":
+                continue
+            print(f"\n{'='*60}")
+            print(f"  Running: {name}")
+            print(f"{'='*60}")
+            func(gpu_id, duration)
+    else:
+        TESTS[args.test](gpu_id, duration)
+
+    print("\n" + "="*60)
+    print("Done. Check healthagent output with: sudo health -s")
+    print("To clear injected values: python3 test_inject.py --test clear")
+
+
+if __name__ == "__main__":
+    main()

--- a/integration/test_inject.py
+++ b/integration/test_inject.py
@@ -59,11 +59,11 @@ FI_CLOCKS_EVENT_REASONS      = 112
 FI_PERSISTENCE_MODE          = 65
 FI_ECC_DBE_VOL_TOTAL         = 311
 FI_ROW_REMAP_FAILURE         = 395
-FI_RETIRED_SBE               = 390
+FI_RETIRED_PENDING           = 392
 FI_FABRIC_MANAGER_STATUS     = 170
 FI_RECOVERY_ACTION           = 1523
-FI_ECC_SBE_AGG_TOTAL         = 312
 FI_PCIE_REPLAY_COUNTER       = 202
+FI_EFFECTIVE_BER_FLOAT       = 1218
 FI_FABRIC_HEALTH_MASK        = 174
 FI_XID_ERRORS                = 230
 
@@ -71,9 +71,9 @@ FI_XID_ERRORS                = 230
 # ── Test functions ─────────────────────────────────────────────
 
 def test_temperature(gpu_id, duration):
-    """Inject GPU temp 95°C — triggers gt error (> 90)."""
-    print(f"\n=== GPU {gpu_id}: Temperature (warning > 83, error > 90) ===")
-    inject_loop(gpu_id, FI_GPU_TEMP, 95, duration, "GPU_TEMP (error)")
+    """Inject GPU temp 95°C — triggers gt warning (> 93)."""
+    print(f"\n=== GPU {gpu_id}: Temperature (warning > 93) ===")
+    inject_loop(gpu_id, FI_GPU_TEMP, 95, duration, "GPU_TEMP (warning)")
 
 
 def test_clocks(gpu_id, duration):
@@ -106,10 +106,10 @@ def test_row_remap(gpu_id, duration):
     inject_loop(gpu_id, FI_ROW_REMAP_FAILURE, 1, duration, "ROW_REMAP_FAILURE")
 
 
-def test_retired_sbe(gpu_id, duration):
-    """Inject retired SBE pages = 65 — triggers gt error (> 63)."""
-    print(f"\n=== GPU {gpu_id}: Retired SBE pages (warning > 50, error > 63) ===")
-    inject_loop(gpu_id, FI_RETIRED_SBE, 65, duration, "RETIRED_SBE (error)")
+def test_retired_pending(gpu_id, duration):
+    """Inject retired pending pages = 1 — triggers gt warning (> 0)."""
+    print(f"\n=== GPU {gpu_id}: Retired pending pages (warning > 0) ===")
+    inject_loop(gpu_id, FI_RETIRED_PENDING, 1, duration, "RETIRED_PENDING (warning)")
 
 
 def test_fabric_status(gpu_id, duration):
@@ -134,16 +134,16 @@ def test_fabric_health(gpu_id, duration):
     inject_loop(gpu_id, FI_FABRIC_HEALTH_MASK, 0x19A, duration, "FABRIC_HEALTH_MASK (route_unhealthy)")
 
 
+def test_ber(gpu_id, duration):
+    """Inject effective BER float = 1e-5 — triggers gt warning (> 1e-6)."""
+    print(f"\n=== GPU {gpu_id}: Effective BER (warning > 1e-6) ===")
+    inject_loop(gpu_id, FI_EFFECTIVE_BER_FLOAT, 1e-5, duration, "EFFECTIVE_BER_FLOAT (warning)")
+
+
 def test_recovery_action(gpu_id, duration):
     """Inject recovery action = 3 (GPU_RESET) — triggers in [3, 4] error."""
     print(f"\n=== GPU {gpu_id}: Recovery action (warning [2], error [3, 4]) ===")
     inject_loop(gpu_id, FI_RECOVERY_ACTION, 3, duration, "RECOVERY_ACTION (GPU_RESET)")
-
-
-def test_sbe_rate(gpu_id, duration):
-    """Inject high SBE aggregate counter — triggers delta_gt."""
-    print(f"\n=== GPU {gpu_id}: SBE aggregate rate (delta_gt warning > 100/min) ===")
-    inject_loop(gpu_id, FI_ECC_SBE_AGG_TOTAL, 99999, duration, "SBE_AGG_TOTAL")
 
 
 def test_xid(gpu_id, duration):
@@ -162,11 +162,11 @@ def test_clear(gpu_id, duration):
         (FI_PERSISTENCE_MODE, 1, "PERSISTENCE_MODE"),
         (FI_ECC_DBE_VOL_TOTAL, 0, "DBE_VOL_TOTAL"),
         (FI_ROW_REMAP_FAILURE, 0, "ROW_REMAP_FAILURE"),
-        (FI_RETIRED_SBE, 0, "RETIRED_SBE"),
+        (FI_RETIRED_PENDING, 0, "RETIRED_PENDING"),
         (FI_FABRIC_MANAGER_STATUS, 3, "FABRIC_STATUS (success)"),
         (FI_FABRIC_HEALTH_MASK, 0x1AA, "FABRIC_HEALTH_MASK (healthy)"),
         (FI_RECOVERY_ACTION, 0, "RECOVERY_ACTION"),
-        (FI_ECC_SBE_AGG_TOTAL, 0, "SBE_AGG_TOTAL"),
+        (FI_EFFECTIVE_BER_FLOAT, 0.0, "EFFECTIVE_BER_FLOAT"),
         (FI_PCIE_REPLAY_COUNTER, 0, "PCIE_REPLAY_COUNTER"),
         (FI_XID_ERRORS, 0, "XID_ERRORS"),
     ]
@@ -184,11 +184,11 @@ TESTS = {
     "persist":  test_persistence_mode,
     "dbe":      test_dbe,
     "remap":    test_row_remap,
-    "sbe":      test_retired_sbe,
+    "pending":  test_retired_pending,
+    "ber":      test_ber,
     "fabric":   test_fabric_status,
     "fabric_health": test_fabric_health,
     "recovery": test_recovery_action,
-    "sberate":  test_sbe_rate,
     "xid":      test_xid,
     "clear":    test_clear,
 }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -87,19 +87,19 @@ class TestLoadConfig:
 
     def test_loads_defaults_only(self, tmp_path):
         """When no config.yaml exists, returns packaged defaults as HealthagentConfig."""
-        defaults = {"modules": ["gpu", "network"], "gpu": {"max_keep_samples": 200}}
+        defaults = {"modules": ["gpu", "network"], "gpu": {"xid": {"warning": [43]}}}
 
         with patch("healthagent.config._load_packaged_defaults", return_value=defaults):
             config = load_config(config_path=str(tmp_path / "nonexistent.yaml"))
 
         assert isinstance(config, HealthagentConfig)
         assert config.modules == [ModuleName.GPU, ModuleName.NETWORK]
-        assert config.gpu.max_keep_samples == 200
+        assert config.gpu.xid.warning == [43]
 
     def test_merges_overrides(self, tmp_path):
         """User config.yaml overrides are merged into packaged defaults."""
-        defaults = {"modules": ["gpu", "network"], "gpu": {"max_keep_samples": 300}}
-        overrides = {"gpu": {"max_keep_samples": 150}}
+        defaults = {"modules": ["gpu", "network"], "gpu": {"xid": {"warning": [43, 63]}}}
+        overrides = {"gpu": {"xid": {"warning": [99]}}}
 
         config_file = tmp_path / "config.yaml"
         config_file.write_text(yaml.dump(overrides))
@@ -107,7 +107,7 @@ class TestLoadConfig:
         with patch("healthagent.config._load_packaged_defaults", return_value=defaults):
             config = load_config(config_path=str(config_file))
 
-        assert config.gpu.max_keep_samples == 150
+        assert config.gpu.xid.warning == [99]
         assert config.modules == [ModuleName.GPU, ModuleName.NETWORK]
 
     def test_null_override_removes_key(self, tmp_path):
@@ -133,7 +133,7 @@ class TestLoadConfig:
 
         assert isinstance(config, HealthagentConfig)
         assert len(config.modules) > 0
-        assert config.gpu.max_keep_samples == 300
+        assert config.gpu.gpudiagnosticcheck.prolog.tests == "short"
 
 
 # ── HealthModule config injection tests ─────────────────────
@@ -197,10 +197,10 @@ class TestSchemaValidation:
                 "network": {"infiniband": {"state": {"eval": "gt", "typo_field": 1}}}
             })
 
-    def test_bad_max_keep_samples_type(self):
-        """gpu.max_keep_samples must be int."""
+    def test_bad_xid_warning_element_type(self):
+        """gpu.xid.warning must be list of ints."""
         with pytest.raises(ValidationError):
-            HealthagentConfig.model_validate({"gpu": {"max_keep_samples": "not_int"}})
+            HealthagentConfig.model_validate({"gpu": {"xid": {"warning": ["not_int"]}}})
 
     def test_bad_services_element_type(self):
         """services list must contain strings."""
@@ -230,9 +230,9 @@ class TestSchemaValidation:
         """model_dump produces a dict that can be re-validated."""
         config = HealthagentConfig.model_validate({
             "modules": ["gpu", "network"],
-            "gpu": {"max_keep_samples": 500},
+            "gpu": {"xid": {"warning": [43, 63]}},
         })
         dumped = config.model_dump()
         reloaded = HealthagentConfig.model_validate(dumped)
-        assert reloaded.gpu.max_keep_samples == 500
+        assert reloaded.gpu.xid.warning == [43, 63]
         assert reloaded.modules == [ModuleName.GPU, ModuleName.NETWORK]

--- a/tests/test_healthmodule.py
+++ b/tests/test_healthmodule.py
@@ -498,7 +498,69 @@ def test_status_no_pruning_when_all_keys_valid():
 
     assert len(reporter.store) == 2
     assert "ActiveGPUHealthChecks" in result
-    assert "NvlinkCheck" in result
+
+
+# --- Tests for _phase injection ---
+
+class FakePhaseAwareModule(HealthModule):
+    """Module with a handler that accepts _phase to apply phase-specific defaults."""
+
+    DEFAULTS = {
+        "prolog": {"level": "1"},
+        "epilog": {"level": "2"},
+    }
+
+    @healthcheck("PhaseCheck", args=["level"])
+    @prolog
+    @epilog
+    async def phase_check(self, level: str = '', _phase: str = None):
+        defaults = self.DEFAULTS.get(_phase, {})
+        level = level or defaults.get("level", "")
+        return {"PhaseCheck": {"level": level, "phase": _phase}}
+
+
+class FakePhaseUnawareModule(HealthModule):
+    """Module with a handler that does NOT accept _phase — should still work."""
+
+    @healthcheck("SimpleCheck")
+    @epilog
+    async def simple_check(self):
+        return {"SimpleCheck": {"status": "OK"}}
+
+
+async def test_phase_injected_for_epilog():
+    """Handler with _phase param receives 'epilog' when run via epilog."""
+    reporter = Reporter()
+    mod = FakePhaseAwareModule(reporter=reporter)
+    result = await mod.execute("epilog", checks={"PhaseCheck": {}})
+    assert result["PhaseCheck"]["phase"] == "epilog"
+    assert result["PhaseCheck"]["level"] == "2"
+
+
+async def test_phase_injected_for_prolog():
+    """Handler with _phase param receives 'prolog' when run via prolog."""
+    reporter = Reporter()
+    mod = FakePhaseAwareModule(reporter=reporter)
+    result = await mod.execute("prolog", checks={"PhaseCheck": {}})
+    assert result["PhaseCheck"]["phase"] == "prolog"
+    assert result["PhaseCheck"]["level"] == "1"
+
+
+async def test_explicit_kwarg_overrides_phase_default():
+    """Explicitly provided kwargs should override phase defaults."""
+    reporter = Reporter()
+    mod = FakePhaseAwareModule(reporter=reporter)
+    result = await mod.execute("epilog", checks={"PhaseCheck": {"level": "3"}})
+    assert result["PhaseCheck"]["level"] == "3"
+    assert result["PhaseCheck"]["phase"] == "epilog"
+
+
+async def test_phase_not_injected_when_not_in_signature():
+    """Handlers without _phase in signature should not receive it."""
+    reporter = Reporter()
+    mod = FakePhaseUnawareModule(reporter=reporter)
+    result = await mod.execute("epilog")
+    assert result["SimpleCheck"]["status"] == "OK"
 
 
 def test_status_prunes_with_empty_registry():


### PR DESCRIPTION
- Set policy only for XIDs and remove policy as a top level healthcheck to avoid duplicating results.
- Consolidate background healthcheck results to avoid duplication.
- Control golden list of de-depuplicated errors that identify unique issues in background healthchecks.
- Use field watches for other issues.