### PR TITLE
Add a cli exclude flag to exclude details from CLI output

### DIFF
--- a/healthagent/reporter.py
+++ b/healthagent/reporter.py
@@ -1,6 +1,6 @@
 import copy
 from enum import Enum
-from dataclasses import dataclass, asdict, is_dataclass, field, InitVar
+from dataclasses import dataclass, asdict, is_dataclass, field, fields, InitVar
 from datetime import datetime, timedelta, timezone
 from time import time
 from typing import Any, Dict
@@ -72,8 +72,8 @@ class HealthReport:
     message: str = None
     "One line description describing the details"
     description: str = None
-    "Detailed message"
-    details: str = None
+    "Detailed message — excluded from CLI output, only sent to CycleCloud UI"
+    details: str = field(default=None, metadata={"cli_exclude": True})
     "recommended actions"
     recommendations :str = None
     "Last time the report was updated"
@@ -118,12 +118,15 @@ class HealthReport:
         if new_status > self.status:
             self.status = new_status
 
-    def view(self) -> Dict[str, Any]:
+    def view(self, cli_exclude: bool = True) -> Dict[str, Any]:
         """
         View method shows the healthreport in its final form.
         aux_data is an InitVar and is excluded from asdict() automatically.
         Custom fields are module specific and are merged to top_level.
+        cli_exclude: when True, fields marked with metadata={"cli_exclude": True} are omitted.
         """
+        # Collect fields to exclude based on metadata
+        exclude = {f.name for f in fields(self) if f.metadata.get("cli_exclude")} if cli_exclude else set()
         # Convert the dataclass to a dictionary
         base_dict = make_json_safe(asdict(self))
         # Merge custom_fields into the top-level dictionary
@@ -133,7 +136,7 @@ class HealthReport:
         filtered_dict = {
             key: (value.value if isinstance(value, Enum) else value)
             for key, value in base_dict.items()
-            if value is not None
+            if value is not None and key not in exclude
         }
         return filtered_dict
 
@@ -178,7 +181,7 @@ class Reporter:
 
         response = {}
         for name, report in self.store.items():
-            response[name] = report.view()
+            response[name] = report.view(cli_exclude=True)
         return response
 
     async def clear_all_errors(self, delta: timedelta = None):

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -195,6 +195,37 @@ def test_aux_data_defaults_to_none():
     assert report.aux_data is None
 
 
+def test_view_cli_excludes_marked_fields():
+    """view(cli_exclude=True) should omit fields marked with cli_exclude metadata."""
+    report = HealthReport(
+        status=HealthStatus.ERROR,
+        description="GPU failure",
+        details="long error trace here",
+    )
+    view_full = report.view()
+    assert "details" in view_full
+
+    view_cli = report.view(cli_exclude=True)
+    assert "details" not in view_cli
+    assert view_cli["status"] == "Error"
+    assert view_cli["description"] == "GPU failure"
+
+
+def test_summarize_excludes_details():
+    """summarize() should not include 'details' in its output."""
+    reporter = Reporter()
+    reporter.publish_cc = False
+    report = HealthReport(
+        status=HealthStatus.ERROR,
+        description="fail",
+        details="verbose error log",
+    )
+    reporter.store["test"] = report
+    summary = reporter.summarize()
+    assert "details" not in summary["test"]
+    assert summary["test"]["description"] == "fail"
+
+
 async def test_aux_data_persisted_on_dedup():
     """aux_data should be updated even when visible report fields are unchanged."""
     reporter = Reporter()


### PR DESCRIPTION
Details is unstructured string text that is useful for cyclecloud UI but not very useful for structured CLI JSON output that can be sent for further processing to various tools.

So continue passing details to CC but ignore it in CLI.