### PR TITLE
Add initial implementation to add configuration for healthagent.

### DIFF
--- a/healthagent/async_systemd.py
+++ b/healthagent/async_systemd.py
@@ -20,8 +20,8 @@ class SystemdMonitor(HealthModule):
     documentation: https://www.freedesktop.org/wiki/Software/systemd/dbus/
     """
 
-    def __init__(self, reporter: Reporter):
-        super().__init__(reporter)
+    def __init__(self, reporter: Reporter, config: dict | None = None):
+        super().__init__(reporter, config)
         self.state = dict()
         self.bus = None
         self.manager = None

--- a/healthagent/client.py
+++ b/healthagent/client.py
@@ -3,6 +3,7 @@ import logging
 import sys
 import socket
 import json
+import yaml
 
 SOCKET_PATH = "/opt/healthagent/run/health.sock"
 MESSAGE_SIZE = 4096
@@ -155,6 +156,10 @@ def main():
         choices=["all", "epilog", "prolog"],
         help="List available checks by type (default: all). Example: health -l epilog"
     )
+    group.add_argument(
+        "-C", "--show-config", action="store_true",
+        help="Show the effective (merged) configuration loaded by the running daemon"
+    )
 
     parser.add_argument(
         "-c", "--check", action="append", nargs="+", metavar="NAME",
@@ -170,7 +175,7 @@ def main():
         level=logging.ERROR
         )
 
-    if not (args.epilog or args.prolog or args.version or args.list_checks):
+    if not (args.epilog or args.prolog or args.version or args.list_checks or args.show_config):
         args.status = True
 
     checks = parse_check_args(args.check)
@@ -178,7 +183,12 @@ def main():
     if checks and not (args.epilog or args.prolog):
         parser.error("-c/--check can only be used with -e/--epilog or -p/--prolog")
 
-    if args.list_checks:
+    if args.show_config:
+        response = get_response(command={"command": "show_config"}, timeout=10)
+        if not response:
+            sys.exit(-1)
+        print(yaml.safe_dump(response, default_flow_style=False, sort_keys=False))
+    elif args.list_checks:
         command = {"command": "list_checks", "type": "all"}
         response = get_response(command=command, timeout=10)
         if not response:

--- a/healthagent/config.py
+++ b/healthagent/config.py
@@ -1,0 +1,60 @@
+import os
+import logging
+import importlib.resources
+import yaml
+
+log = logging.getLogger(__name__)
+
+CONFIG_DIR = "/etc/healthagent"
+CONFIG_FILE = f"{CONFIG_DIR}/config.yaml"
+
+
+def deep_merge(base: dict, override: dict) -> dict:
+    """Recursively merge override into base.
+
+    Rules:
+      - dicts: recursive merge
+      - lists/scalars: override replaces base
+      - null value: removes the key from the result (explicit deletion)
+    """
+    merged = dict(base)
+    for key, value in override.items():
+        if value is None:
+            merged.pop(key, None)
+        elif key in merged and isinstance(merged[key], dict) and isinstance(value, dict):
+            merged[key] = deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _load_packaged_defaults() -> dict:
+    """Load the defaults.yaml bundled with the package."""
+    with importlib.resources.files("healthagent").joinpath("defaults.yaml").open() as f:
+        return yaml.safe_load(f)
+
+
+def load_config(config_path: str = CONFIG_FILE) -> dict:
+    """Load defaults from the package, then overlay user config if present."""
+
+    config = _load_packaged_defaults()
+
+    if config is None:
+        config = {}
+    if not isinstance(config, dict):
+        raise ValueError(f"defaults.yaml must be a YAML mapping, got {type(config).__name__}")
+
+    log.debug("Loaded default config from package")
+    if os.path.isfile(config_path):
+        log.info(f"Loading config overrides from {config_path}")
+        with open(config_path) as f:
+            overrides = yaml.safe_load(f)
+        if overrides is None:
+            overrides = {}
+        if not isinstance(overrides, dict):
+            raise ValueError(f"{config_path} must be a YAML mapping, got {type(overrides).__name__}")
+        config = deep_merge(config, overrides)
+    else:
+        log.debug(f"No config file at {config_path}")
+
+    return config

--- a/healthagent/defaults.yaml
+++ b/healthagent/defaults.yaml
@@ -1,0 +1,142 @@
+# ──────────────────────────────────────────────────────────
+# Healthagent defaults — shipped with the package.
+# Override any value via /etc/healthagent/config.yaml
+# ──────────────────────────────────────────────────────────
+
+modules:
+  - gpu
+  - systemd
+  - network
+  - kmsg
+  - proc
+
+# ── Network module ──────────────────────────────────────
+network:
+  infiniband:
+    state:
+      eval: ne
+      error: "4: ACTIVE"
+      msg: "IB link is not active"
+    phys_state:
+      eval: ne
+      error: "5: LinkUp"
+      msg: "IB link not in state LinkUp"
+    link_downed:
+      eval: gt
+      error: 3
+      msg: "IB link down count exceeded the threshold"
+    link_error_recovery:
+      eval: gt
+      warning: 3
+      msg: "IB link error recovery exceeded the threshold"
+    operstate:
+      eval: ne
+      warning: up
+      msg: "IPoIB not in state up"
+    carrier_down_count:
+      eval: gt
+      warning: 5
+      msg: "IPoIB carrier down count exceeded threshold"
+  ethernet:
+    carrier_down_count:
+      eval: gt
+      warning: 3
+      msg: "carrier_down_count exceeded threshold"
+    operstate:
+      eval: ne
+      error: up
+      msg: "interface not in state up"
+
+# ── GPU module ──────────────────────────────────────────
+gpu:
+  max_keep_samples: 300
+
+  # By default all XIDS are treated as error.
+  # XIDS in warning list are downgraded to warning.
+  # If error list is explicitly specified, then only
+  # specific XIDS will be treated as ERROR.
+  xid:
+    warning: [43, 63, 13, 31, 66, 94, 154]
+    ignore: []
+    error: []
+
+  diagnostics:
+    prolog:
+      tests: short
+      params: ""
+    epilog:
+      tests: medium
+      params: ""
+
+  field_watches:
+    DCGM_FI_DEV_GPU_TEMP:
+      eval: gt
+      warning: 83
+      error: 90
+      category: Thermal
+      message: "GPU {gpu} temperature {value}°C exceeds {threshold}°C"
+    DCGM_FI_DEV_CLOCKS_EVENT_REASONS:
+      eval: bitmask
+      error: 0xE8
+      category: Clocks
+      message: "GPU {gpu} clock throttle reasons active: {value:#x} (mask: {threshold:#x})"
+    DCGM_FI_DEV_PERSISTENCE_MODE:
+      eval: ne
+      error: 1
+      category: System
+      message: "GPU {gpu} persistence mode not set. Restart nvidia-persistenced or reboot."
+    DCGM_FI_DEV_GET_GPU_RECOVERY_ACTION:
+      eval: in
+      warning: [2]
+      error: [3, 4]
+      category: System
+      message: "GPU {gpu} recovery action requested (action: {value})"
+    DCGM_FI_DEV_ROW_REMAP_FAILURE:
+      eval: ne
+      error: 0
+      category: Memory
+      message: "GPU {gpu} row remap failure detected"
+    DCGM_FI_DEV_ECC_DBE_VOL_TOTAL:
+      eval: gt
+      error: 0
+      category: Memory
+      message: "GPU {gpu} volatile DBE errors detected: {value}"
+    DCGM_FI_DEV_RETIRED_SBE:
+      eval: gt
+      warning: 50
+      error: 63
+      category: Memory
+      message: "GPU {gpu} retired SBE pages: {value} (threshold: {threshold})"
+    DCGM_FI_DEV_ECC_SBE_AGG_TOTAL:
+      eval: delta_gt
+      warning: 100
+      category: Memory
+      message: "GPU {gpu} SBE rate {value:.0f}/min exceeds {threshold}/min"
+    DCGM_FI_DEV_PCIE_REPLAY_COUNTER:
+      eval: delta_gt
+      warning: 50
+      error: 200
+      category: PCIe
+      message: "GPU {gpu} PCIe replay rate {value:.0f}/min exceeds {threshold}/min"
+
+# ── Systemd module ──────────────────────────────────────
+systemd:
+  base_services:
+    - munge.service
+    - slurmd.service
+    - slurmctld.service
+    - slurmdbd.service
+    - slurmrestd.service
+  gpu_services:
+    - nvidia-imex.service
+    - nvidia-dcgm.service
+    - nvidia-persistenced.service
+
+# ── Process module ──────────────────────────────────────
+proc:
+  zombie_per_core: 50
+  pid_max_warn_pct: 10
+  pid_saturation_pct: 50
+
+# ── Kmsg module ─────────────────────────────────────────
+kmsg: {}

--- a/healthagent/gpu.py
+++ b/healthagent/gpu.py
@@ -20,9 +20,9 @@ class GpuNotFoundException(Exception):
 
 class GpuHealthChecks(HealthModule):
 
-    def __init__(self, reporter: Reporter):
+    def __init__(self, reporter: Reporter, config: dict | None = None):
 
-        super().__init__(reporter)
+        super().__init__(reporter, config)
 
         # TODO: Move this to config file
         self.test_mode = os.getenv('DCGM_TEST_MODE', 'false').lower() == 'true'

--- a/healthagent/healthagent.py
+++ b/healthagent/healthagent.py
@@ -10,6 +10,7 @@ from time import perf_counter
 from healthagent.scheduler import Scheduler
 from healthagent.reporter import Reporter
 from healthagent.profiler import Profiler
+from healthagent.config import load_config
 from importlib.metadata import version, PackageNotFoundError
 
 try:
@@ -149,6 +150,8 @@ class Healthagent:
                 response = cls._list_module_checks(attribute_flag=flag)
             elif command == "version":
                 response = VERSION
+            elif command == "show_config":
+                response = cls.config
             else:
                 raise ValueError("Invalid message received")
 
@@ -184,12 +187,29 @@ class Healthagent:
 
     @classmethod
     async def initialize_modules(cls):
+        cls.config = load_config()
+        enabled = cls.config.get("modules", [])
+        if not isinstance(enabled, list) or not all(isinstance(m, str) for m in enabled):
+            raise ValueError(
+                f"'modules' in config must be a list of strings, got: {enabled!r}"
+            )
+
         for module_name, import_path, class_name in cls.MODULE_REGISTRY:
+            if module_name not in enabled:
+                log.info(f"Module {module_name} disabled by config")
+                continue
             try:
                 mod = importlib.import_module(import_path)
                 instance = getattr(mod, class_name)
                 reporter = cls.get_reporter(module=module_name)
-                instance_obj = instance(reporter=reporter)
+                module_config = cls.config.get(module_name, {})
+                if module_config is None:
+                    module_config = {}
+                if not isinstance(module_config, dict):
+                    raise ValueError(
+                        f"Config for module '{module_name}' must be a YAML mapping, got: {type(module_config).__name__!r}"
+                    )
+                instance_obj = instance(reporter=reporter, config=module_config)
                 await instance_obj.create()
                 log.info(f"Initialized module: {module_name}")
             except ImportError as e:

--- a/healthagent/healthmodule.py
+++ b/healthagent/healthmodule.py
@@ -17,8 +17,9 @@ class HealthModule(ABC):
 
     """
 
-    def __init__(self, reporter: Reporter):
+    def __init__(self, reporter: Reporter, config: dict | None = None):
         self.reporter = reporter
+        self.config = config if config is not None else {}
         self._handler_cache = {}
         self._checks_registry = None
 

--- a/healthagent/install.py
+++ b/healthagent/install.py
@@ -1,9 +1,17 @@
 import os
 import shutil
+import importlib.resources
 
 def main():
     etc_dir = "/etc/healthagent"
     os.makedirs(etc_dir, exist_ok=True)
+
+    # Copy defaults.yaml to /etc/healthagent/ for operator reference
+    defaults_src = importlib.resources.files("healthagent").joinpath("defaults.yaml")
+    defaults_dst = os.path.join(etc_dir, "defaults.yaml")
+    with importlib.resources.as_file(defaults_src) as src_path:
+        shutil.copy2(str(src_path), defaults_dst)
+    print(f"Copied defaults.yaml to {defaults_dst}")
 
     # Copy example scripts
     for fname in ["health.sh.example", "epilog.sh.example"]:

--- a/healthagent/kmsg.py
+++ b/healthagent/kmsg.py
@@ -12,9 +12,9 @@ log = logging.getLogger(__name__)
 
 class KmsgReader(HealthModule):
 
-    def __init__(self, reporter: Reporter):
+    def __init__(self, reporter: Reporter, config: dict | None = None):
 
-        super().__init__(reporter)
+        super().__init__(reporter, config)
         try:
             self.fd = os.open("/dev/kmsg", os.O_RDONLY | os.O_NONBLOCK)
         except Exception as e:

--- a/healthagent/network.py
+++ b/healthagent/network.py
@@ -62,8 +62,8 @@ class NetworkInterface:
 
 class NetworkHealthChecks(HealthModule):
 
-    def __init__(self, reporter: Reporter):
-        super().__init__(reporter)
+    def __init__(self, reporter: Reporter, config: dict | None = None):
+        super().__init__(reporter, config)
 
     async def create(self):
         await self.reporter.clear_all_errors()

--- a/healthagent/process.py
+++ b/healthagent/process.py
@@ -28,8 +28,8 @@ class ProcessMonitor(HealthModule):
     PID_MAX_WARN_PCT = 10           # warn at 10% of pid_max
     PID_SATURATION_PCT = 50         # error at 50% of pid_max
 
-    def __init__(self, reporter: Reporter):
-        super().__init__(reporter)
+    def __init__(self, reporter: Reporter, config: dict | None = None):
+        super().__init__(reporter, config)
         self.pid_max = self._read_pid_max()
         self.cpu_count = os.cpu_count() or 1
         self.zombie_warn_threshold = min(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "healthagent"
 version = "2.0.0"
-dependencies = ["dbus-next", "systemd-python", "pytest-asyncio"]
+dependencies = ["dbus-next", "systemd-python", "pytest-asyncio", "pyyaml"]
 
 [project.optional-dependencies]
 gpu = ["cuda-bindings"]
@@ -23,7 +23,7 @@ healthagent-install = "healthagent.install:main"
 include-package-data = true
 
 [tool.setuptools.package-data]
-healthagent = ["logging.conf", "etc/*", "tools/*"]
+healthagent = ["logging.conf", "defaults.yaml", "etc/*", "tools/*"]
 
 [tool.setuptools.packages.find]
 include = ["healthagent"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,154 @@
+import yaml
+from unittest.mock import patch
+
+from healthagent.config import deep_merge, load_config
+from healthagent.healthmodule import HealthModule
+from healthagent.reporter import Reporter
+
+
+# ── deep_merge tests ────────────────────────────────────────
+
+class TestDeepMerge:
+
+    def test_scalar_override(self):
+        base = {"a": 1, "b": 2}
+        override = {"b": 99}
+        result = deep_merge(base, override)
+        assert result == {"a": 1, "b": 99}
+
+    def test_list_replace(self):
+        base = {"services": ["a", "b", "c"]}
+        override = {"services": ["x", "y"]}
+        result = deep_merge(base, override)
+        assert result == {"services": ["x", "y"]}
+
+    def test_dict_recursive_merge(self):
+        base = {"gpu": {"warning": 83, "error": 90, "category": "Thermal"}}
+        override = {"gpu": {"warning": 78}}
+        result = deep_merge(base, override)
+        assert result == {"gpu": {"warning": 78, "error": 90, "category": "Thermal"}}
+
+    def test_null_removes_key(self):
+        base = {"a": 1, "b": 2, "c": 3}
+        override = {"b": None}
+        result = deep_merge(base, override)
+        assert result == {"a": 1, "c": 3}
+
+    def test_null_removes_nested_key(self):
+        base = {"gpu": {"field_watches": {"TEMP": {"warn": 83}, "PCIE": {"warn": 50}}}}
+        override = {"gpu": {"field_watches": {"TEMP": None}}}
+        result = deep_merge(base, override)
+        assert result == {"gpu": {"field_watches": {"PCIE": {"warn": 50}}}}
+
+    def test_null_nonexistent_key_is_noop(self):
+        base = {"a": 1}
+        override = {"nonexistent": None}
+        result = deep_merge(base, override)
+        assert result == {"a": 1}
+
+    def test_new_key_added(self):
+        base = {"a": 1}
+        override = {"b": 2}
+        result = deep_merge(base, override)
+        assert result == {"a": 1, "b": 2}
+
+    def test_deeply_nested(self):
+        base = {"l1": {"l2": {"l3": {"val": "old", "keep": True}}}}
+        override = {"l1": {"l2": {"l3": {"val": "new"}}}}
+        result = deep_merge(base, override)
+        assert result == {"l1": {"l2": {"l3": {"val": "new", "keep": True}}}}
+
+    def test_override_dict_with_scalar(self):
+        """If override replaces a dict with a scalar, scalar wins."""
+        base = {"gpu": {"warning": 83, "error": 90}}
+        override = {"gpu": "disabled"}
+        result = deep_merge(base, override)
+        assert result == {"gpu": "disabled"}
+
+    def test_empty_override(self):
+        base = {"a": 1, "b": {"c": 2}}
+        result = deep_merge(base, {})
+        assert result == base
+
+    def test_empty_base(self):
+        override = {"a": 1}
+        result = deep_merge({}, override)
+        assert result == {"a": 1}
+
+
+# ── load_config tests ───────────────────────────────────────
+
+class TestLoadConfig:
+
+    def test_loads_defaults_only(self, tmp_path):
+        """When no config.yaml exists, returns packaged defaults unchanged."""
+        defaults = {"modules": ["gpu", "network"], "gpu": {"temp": 83}}
+
+        with patch("healthagent.config._load_packaged_defaults", return_value=defaults):
+            config = load_config(config_path=str(tmp_path / "nonexistent.yaml"))
+
+        assert config == defaults
+
+    def test_merges_overrides(self, tmp_path):
+        """User config.yaml overrides are merged into packaged defaults."""
+        defaults = {"modules": ["gpu", "network"], "gpu": {"temp": 83, "error": 90}}
+        overrides = {"gpu": {"temp": 78}}
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(yaml.dump(overrides))
+
+        with patch("healthagent.config._load_packaged_defaults", return_value=defaults):
+            config = load_config(config_path=str(config_file))
+
+        assert config["gpu"]["temp"] == 78
+        assert config["gpu"]["error"] == 90
+        assert config["modules"] == ["gpu", "network"]
+
+    def test_null_override_removes_key(self, tmp_path):
+        """null in config.yaml removes a default key."""
+        defaults = {"gpu": {"field_watches": {"TEMP": {"warn": 83}, "PCIE": {"warn": 50}}}}
+        overrides = {"gpu": {"field_watches": {"TEMP": None}}}
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(yaml.dump(overrides))
+
+        with patch("healthagent.config._load_packaged_defaults", return_value=defaults):
+            config = load_config(config_path=str(config_file))
+
+        assert "TEMP" not in config["gpu"]["field_watches"]
+        assert config["gpu"]["field_watches"]["PCIE"] == {"warn": 50}
+
+    def test_loads_packaged_defaults(self, tmp_path):
+        """Always loads packaged defaults.yaml when no user config is present."""
+        config = load_config(config_path=str(tmp_path / "nonexistent.yaml"))
+
+        # Should have loaded the real packaged defaults.yaml
+        assert "modules" in config
+        assert "gpu" in config
+
+
+# ── HealthModule config injection tests ─────────────────────
+
+class TestHealthModuleConfig:
+
+    def test_config_defaults_to_empty_dict(self):
+        """When no config is passed, self.config is an empty dict."""
+        class FakeModule(HealthModule):
+            pass
+        module = FakeModule(reporter=Reporter())
+        assert module.config == {}
+
+    def test_config_is_stored(self):
+        """When config is passed, it's available as self.config."""
+        class FakeModule(HealthModule):
+            pass
+        test_config = {"temp": 83, "services": ["a", "b"]}
+        module = FakeModule(reporter=Reporter(), config=test_config)
+        assert module.config == test_config
+
+    def test_config_none_becomes_empty_dict(self):
+        """Passing None explicitly results in empty dict."""
+        class FakeModule(HealthModule):
+            pass
+        module = FakeModule(reporter=Reporter(), config=None)
+        assert module.config == {}


### PR DESCRIPTION
- Add pyyaml to dependencies and defaults.yaml for default config
- Add a config module for loading/merging default and user config
- Allow healthmodule to initialize config
- Intialize config and pass it to all healthmodules.
- Install defaults.yaml
- Add health -C cli. show-config option shows the currently loaded config.