### PR TITLE
Schedule epilog diagnostic tests.

### DIFF
--- a/healthagent/scheduler.py
+++ b/healthagent/scheduler.py
@@ -13,6 +13,7 @@ class Scheduler:
     """
     stop_event = None
     _pool = None
+    _pool_lock = None
 
     @staticmethod
     def pool(func):
@@ -87,6 +88,22 @@ class Scheduler:
         self.cancel_event.set()
 
     @classmethod
+    async def _run_pool_task(self, function, *args, **kwargs):
+        """Run a pool task under _pool_lock to serialize DCGM diagnostics."""
+        async with self._pool_lock:
+            loop = asyncio.get_running_loop()
+            pool = ProcessPoolExecutor(
+                max_workers=1,
+                mp_context=multiprocessing.get_context("spawn")
+            )
+            try:
+                return await loop.run_in_executor(pool, functools.partial(function, *args, **kwargs))
+            finally:
+                # Offload the (potentially blocking) shutdown to a thread and shield
+                # it from cancellation so the pool is always cleaned up.
+                await asyncio.shield(loop.run_in_executor(None, pool.shutdown, True))
+
+    @classmethod
     def add_task(self, function, *args, **kwargs):
         """
         Add an on-demand task to be run at the time defined by when,
@@ -100,19 +117,7 @@ class Scheduler:
         if not pool:
             return asyncio.create_task(self.__task_wrapper(interval, function, *args, **kwargs))
         else:
-            loop = asyncio.get_running_loop()
-            pool = ProcessPoolExecutor(
-                max_workers=1,
-                mp_context=multiprocessing.get_context("spawn")
-            )
-            future = loop.run_in_executor(pool, functools.partial(function, *args, **kwargs))
-
-            # Clean up pool once future is done
-            def shutdown_pool(_):
-                pool.shutdown(wait=True)
-
-            future.add_done_callback(shutdown_pool)
-            return future
+            return asyncio.create_task(self._run_pool_task(function, *args, **kwargs))
 
     def subprocess(*sp_args, **sp_kwargs):
         # Set defaults only if not already specified
@@ -135,6 +140,7 @@ class Scheduler:
     def start(self):
         self.stop_event = asyncio.Event()
         self.cancel_event = asyncio.Event()
+        self._pool_lock = asyncio.Lock()
         self.stop_event.clear()
 
     @classmethod

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -62,6 +62,16 @@ def on_demand_task(sleep_t: int = 1):
     return sleep_t
 
 @Scheduler.pool
+def on_demand_timed_task(sleep_t: float = 1):
+
+    # Record wall-clock start/end so the parent can verify pool tasks
+    # do not overlap (i.e. they are serialized by _pool_lock).
+    start = time()
+    sleep(sleep_t)
+    end = time()
+    return (start, end)
+
+@Scheduler.pool
 def on_demand_task_kwargs(value: int = 1, multiplier: int = 1):
 
     return value * multiplier
@@ -138,6 +148,26 @@ async def test_pool_kwargs():
     rc = await Scheduler.add_task(on_demand_task_kwargs, value=5, multiplier=3)
     assert rc == 15
     Scheduler.stop()
+
+
+async def test_pool_serialized():
+    """
+    Tests that concurrently scheduled @Scheduler.pool tasks are serialized by
+    _pool_lock and do not overlap, even though each runs in its own process.
+    """
+
+    Scheduler.start()
+    # Schedule two pool tasks at the same time. Each blocks for 2 seconds and
+    # reports its own wall-clock start/end timestamps.
+    t1 = Scheduler.add_task(on_demand_timed_task, 2)
+    t2 = Scheduler.add_task(on_demand_timed_task, 2)
+    (start1, end1), (start2, end2) = await asyncio.gather(t1, t2)
+    Scheduler.stop()
+
+    # Order the two runs by start time and assert the second starts only after
+    # the first finishes (no overlap).
+    first, second = sorted([(start1, end1), (start2, end2)])
+    assert second[0] >= first[1]
 
 
 async def test_on_demand():


### PR DESCRIPTION
DCGM does not allow tests to run concurrently even if they are run on separate GPU's. For this reason, schedule the tests to run one after the other using locks. So at one point only one run can be scheduled.